### PR TITLE
chore: minor improvements to the `byte_lookup` example

### DIFF
--- a/examples/byte_lookup/Cargo.toml
+++ b/examples/byte_lookup/Cargo.toml
@@ -11,5 +11,4 @@ p3-baby-bear = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1-
 p3-field = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1-new" }
 p3-matrix = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1-new" }
 p3-uni-stark = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1-new" }
-rayon = "1.10.0"
 wp1-core = { git = "ssh://git@github.com/wormhole-foundation/wp1.git", branch = "dev" }

--- a/examples/byte_lookup/src/symbolic_builder.rs
+++ b/examples/byte_lookup/src/symbolic_builder.rs
@@ -33,7 +33,6 @@ impl<F: Field> LookupAirBuilder<SymbolicExpression<F>> for SymbolicBuilder<F> {
 }
 
 impl<F: Field> SymbolicBuilder<F> {
-    /// Creates a new `InteractionBuilder` with the given width.
     #[allow(dead_code)]
     fn new(main_width: usize) -> Self {
         let main_values = [0, 1]


### PR DESCRIPTION
* Lower the bar for some type constraints
* Remove parallelism from debugging function for cleaner error reports