### PR TITLE
chore: fix symbol interning

### DIFF
--- a/src/lair/macros.rs
+++ b/src/lair/macros.rs
@@ -316,7 +316,7 @@ macro_rules! block {
                 {
                     $(
                         vec.push((
-                            $crate::lurk::store::Tag::$tag.to_field(),
+                            $crate::lurk::zstore::Tag::$tag.to_field(),
                             $crate::block!( $branch )
                         ));
                         $(

--- a/src/lair/memory.rs
+++ b/src/lair/memory.rs
@@ -40,8 +40,8 @@ impl MemChip {
 
     pub fn generate_trace<F: Field>(&self, queries: &QueryRecord<F>) -> RowMajorMatrix<F> {
         let len = self.len;
-        let idx = mem_index_from_len(len).unwrap();
-        let mem = &queries.mem_queries[idx];
+        let mem_idx = mem_index_from_len(len);
+        let mem = &queries.mem_queries[mem_idx];
         let width = self.width();
         let height = mem.len().next_power_of_two().max(4);
         let mut rows = vec![F::zero(); height * width];
@@ -61,8 +61,8 @@ impl MemChip {
 
     pub fn generate_trace_parallel<F: Field>(&self, queries: &QueryRecord<F>) -> RowMajorMatrix<F> {
         let len = self.len;
-        let idx = mem_index_from_len(len).unwrap();
-        let mem = queries.mem_queries[idx].iter().collect::<Vec<_>>();
+        let mem_idx = mem_index_from_len(len);
+        let mem = queries.mem_queries[mem_idx].iter().collect::<Vec<_>>();
         let width = self.width();
         let height = mem.len().next_power_of_two().max(4);
         let mut rows = vec![F::zero(); height * width];

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -232,7 +232,7 @@ impl<F: PrimeField> Op<F> {
                 }
             }
             Op::Store(args) => {
-                let idx = mem_index_from_len(args.len()).unwrap();
+                let idx = mem_index_from_len(args.len());
                 let query_map = &queries.mem_queries[idx];
                 let args = args.iter().map(|a| map[*a].0).collect::<List<_>>();
                 let i = query_map
@@ -243,7 +243,7 @@ impl<F: PrimeField> Op<F> {
                 slice.push_aux(index, f);
             }
             Op::Load(len, ptr) => {
-                let idx = mem_index_from_len(*len).unwrap();
+                let idx = mem_index_from_len(*len);
                 let query_map = &queries.mem_queries[idx];
                 let ptr: usize = map[*ptr].0.as_canonical_biguint().try_into().unwrap();
                 let (args, _) = query_map

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1,10 +1,10 @@
 use p3_field::{Field, PrimeField};
 
-use crate::{func, lair::expr::FuncE, lurk::store::Tag};
+use crate::{func, lair::expr::FuncE};
 
 use super::{
     memory::Memory,
-    store::{Hasher, ZStore},
+    zstore::{Hasher, Tag, ZStore},
 };
 
 #[derive(Clone, Copy)]
@@ -929,7 +929,7 @@ mod test {
 
     use crate::{
         lair::{chip::FuncChip, execute::QueryRecord, toplevel::Toplevel, List},
-        lurk::store::{PoseidonBabyBearHasher, Tag},
+        lurk::zstore::{PoseidonBabyBearHasher, Tag},
     };
 
     use super::*;

--- a/src/lurk/mod.rs
+++ b/src/lurk/mod.rs
@@ -3,6 +3,6 @@ pub mod memory;
 pub mod package;
 pub mod parser;
 pub mod state;
-pub mod store;
 pub mod symbol;
 pub mod syntax;
+pub mod zstore;


### PR DESCRIPTION
* No longer reverse the symbol path
* Add a test for the fix above

Extra:

* Rename `store.rs` to `zstore.rs` because that's what's defined/implemented
* After #40 we no longer need to tweak raw values for keywords, strings and symbols
* Several QOL improvements