### PR TITLE
optimize: use `FxHashMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ arc-swap = "1.7.1"
 base-x = "0.2.11"
 elsa = { version = "1.9.0", git = "https://github.com/lurk-lab/elsa", branch = "sync_frozen", features = ["indexmap"] }
 expect-test = "1.4.1"
+fxhash = "0.2.1"
 indexmap = { version = "2.2.6", features = ["rayon"] }
 match_opt = "0.1.2"
 nom = "7.1.3"

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, slice::Iter};
+use std::slice::Iter;
 
 use super::{
     bytecode::{Block, Ctrl, Func, Op},
@@ -7,6 +7,7 @@ use super::{
     List,
 };
 
+use fxhash::FxHashMap;
 use indexmap::IndexMap;
 use p3_field::{Field, PrimeField};
 
@@ -16,8 +17,8 @@ pub struct QueryResult<T> {
     pub(crate) mult: u32,
 }
 
-pub(crate) type QueryMap<F> = BTreeMap<List<F>, QueryResult<List<F>>>;
-pub(crate) type InvQueryMap<F> = BTreeMap<List<F>, List<F>>;
+pub(crate) type QueryMap<F> = FxHashMap<List<F>, QueryResult<List<F>>>;
+pub(crate) type InvQueryMap<F> = FxHashMap<List<F>, List<F>>;
 pub(crate) type MemMap<F> = IndexMap<List<F>, u32>;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -81,13 +82,13 @@ impl<F: Field> QueryRecord<F> {
 
     #[inline]
     pub fn new_with_init_mem(toplevel: &Toplevel<F>, mem_queries: Vec<MemMap<F>>) -> Self {
-        let func_queries = vec![BTreeMap::new(); toplevel.size()];
+        let func_queries = vec![FxHashMap::default(); toplevel.size()];
         let inv_func_queries = toplevel
             .map
             .iter()
             .map(|(_, func)| {
                 if func.invertible {
-                    Some(BTreeMap::new())
+                    Some(FxHashMap::default())
                 } else {
                     None
                 }


### PR DESCRIPTION
Use `FxHashMap` instead of `BTreeMap` in `execute.rs` for faster Lair execution.

Here's the `criterion` bench report on my machine:
```
evaluation-500          time:   [4.9294 ms 4.9333 ms 4.9366 ms]                            
                        change: [-39.061% -38.932% -38.824%] (p = 0.00 < 0.05)
                        Performance has improved.

trace-generation-500    time:   [1.0128 ms 1.0193 ms 1.0274 ms]                                 
                        change: [-17.543% -15.752% -13.654%] (p = 0.00 < 0.05)
                        Performance has improved.
```