### PR TITLE
chore: fit a char in a single field element

### DIFF
--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -61,11 +61,11 @@ pub fn ingress<F: PrimeField>() -> FuncE<F> {
         fn ingress(tag_full: [8], digest: [8]): [1] {
             let (tag, _rest: [7]) = tag_full;
             match tag {
-                Tag::Num | Tag::Err => {
+                Tag::Num | Tag::Char | Tag::Err => {
                     let (x, _rest: [7]) = digest;
                     return x
                 }
-                Tag::Char | Tag::Nil | Tag::U64 | Tag::Comm => {
+                Tag::Nil | Tag::U64 | Tag::Comm => {
                     let ptr = store(digest);
                     return ptr
                 }
@@ -116,11 +116,11 @@ pub fn egress<F: PrimeField>() -> FuncE<F> {
         fn egress(tag, val): [8] {
             let zero = 0;
             match tag {
-                Tag::Num | Tag::Err => {
+                Tag::Num | Tag::Char | Tag::Err => {
                     let (digest: [8]) = (val, zero, zero, zero, zero, zero, zero, zero);
                     return digest
                 }
-                Tag::Char | Tag::Nil | Tag::U64 | Tag::Comm => {
+                Tag::Nil | Tag::U64 | Tag::Comm => {
                     let (digest: [8]) = load(val);
                     return digest
                 }

--- a/src/lurk/reader.rs
+++ b/src/lurk/reader.rs
@@ -64,8 +64,8 @@ impl<const N: usize> SizedBuffer<N> {
     }
 
     fn read_char(&mut self, c: char) {
-        self.read_iter((c as u32).to_le_bytes().map(F::from_canonical_u8));
-        self.advance(4);
+        self.read_f(F::from_canonical_u32(c as u32));
+        self.advance(7);
     }
 
     fn extract(self) -> [F; N] {
@@ -97,6 +97,11 @@ impl Default for Reader {
 static NIL: OnceCell<Symbol> = OnceCell::new();
 fn nil() -> &'static Symbol {
     NIL.get_or_init(|| lurk_sym("nil"))
+}
+
+static QUOTE: OnceCell<Symbol> = OnceCell::new();
+fn quote() -> &'static Symbol {
+    QUOTE.get_or_init(|| lurk_sym("quote"))
 }
 
 fn get_symbol_tag(symbol: &Symbol) -> Tag {
@@ -213,7 +218,7 @@ impl Reader {
             }
             Syntax::Quote(_, x) => {
                 let nil_hash = self.read_symbol(nil());
-                let quote_hash = self.read_symbol(&lurk_sym("quote"));
+                let quote_hash = self.read_symbol(quote());
                 let x_hash = self.read_syntax(x);
                 self.hash_list(vec![(Tag::Sym, quote_hash), x_hash], (Tag::Nil, nil_hash))
             }


### PR DESCRIPTION
`char::MAX as u32` is only 1114111 while the order of BabyBear is over 2 billion, meaning that we're able to use a single BabyBear element to represent a char for extra simplicity.

Extra: lazily define and cache the symbol `.lurk.quote` on the reader