### PR TITLE
chore: factor out a `Hasher` trait from the reader

### DIFF
--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -126,13 +126,13 @@ impl<F: Field> QueryRecord<F> {
             let (inp, out) = (inp.into(), out.into());
             let queries = &mut self.func_queries[func.index];
             if !queries.contains_key(&inp) {
-                queries.insert(inp.clone(), QueryResult::init(out.clone()));
                 if func.invertible {
                     self.inv_func_queries[func.index]
                         .as_mut()
                         .expect("Inverse query map not found")
-                        .insert(out, inp);
+                        .insert(out.clone(), inp.clone());
                 }
+                queries.insert(inp, QueryResult::init(out));
             }
         }
     }

--- a/src/lair/hasher.rs
+++ b/src/lair/hasher.rs
@@ -1,0 +1,62 @@
+use p3_baby_bear::BabyBear;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+use p3_symmetric::Permutation;
+
+use crate::poseidon::{
+    config::{BabyBearConfig24, BabyBearConfig32, BabyBearConfig48, InternalDiffusion},
+    Poseidon2Chip,
+};
+
+use super::List;
+
+pub trait Hasher: Default {
+    type F;
+
+    fn hash(&self, preimg: &[Self::F]) -> List<Self::F>;
+}
+
+pub struct LurkHasher {
+    hasher_24_8: Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, InternalDiffusion, 24, 7>,
+    hasher_32_8: Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, InternalDiffusion, 32, 7>,
+    hasher_48_8: Poseidon2<BabyBear, Poseidon2ExternalMatrixGeneral, InternalDiffusion, 48, 7>,
+    // chip_24_8: Poseidon2Chip<BabyBearConfig24>,
+    // chip_32_8: Poseidon2Chip<BabyBearConfig32>,
+    // chip_48_8: Poseidon2Chip<BabyBearConfig48>,
+}
+
+impl Default for LurkHasher {
+    fn default() -> Self {
+        let chip_32_8 = Poseidon2Chip::<BabyBearConfig32>::default();
+        let chip_24_8 = Poseidon2Chip::<BabyBearConfig24>::default();
+        let chip_48_8 = Poseidon2Chip::<BabyBearConfig48>::default();
+        let hasher_24_8 = chip_24_8.hasher();
+        let hasher_32_8 = chip_32_8.hasher();
+        let hasher_48_8 = chip_48_8.hasher();
+        Self {
+            hasher_24_8,
+            hasher_32_8,
+            hasher_48_8,
+            // chip_24_8,
+            // chip_32_8,
+            // chip_48_8,
+        }
+    }
+}
+
+impl Hasher for LurkHasher {
+    type F = BabyBear;
+
+    fn hash(&self, preimg: &[Self::F]) -> List<Self::F> {
+        macro_rules! hash_with {
+            ($name:ident) => {
+                self.$name.permute(preimg.try_into().unwrap())[..8].into()
+            };
+        }
+        match preimg.len() {
+            24 => hash_with!(hasher_24_8),
+            32 => hash_with!(hasher_32_8),
+            48 => hash_with!(hasher_48_8),
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/src/lair/mod.rs
+++ b/src/lair/mod.rs
@@ -9,6 +9,7 @@ pub mod bytecode;
 pub mod chip;
 pub mod execute;
 pub mod expr;
+pub mod hasher;
 mod macros;
 pub mod map;
 pub mod memory;


### PR DESCRIPTION
Create a `Hasher` trait that will enable Lair to be generic on the hasher for a future `Op::Hash`.

Further, create a concrete `LurkHasher` and implement `Hasher` for it. `LurkHasher` knows how to hash preimages of sizes:
* 24 for commitments (8 from secret + 16 from pointer)
* 32 for 2-sized tuples (2 * 16 from two pointers)
* 48 for 3-sized tuples (3 * 16 from three pointers)

The reader, then, uses `LurkHasher` instead of inlining hashing logic.