### PR TITLE
feat: hash operator for Lair

### DIFF
--- a/src/lair/bytecode.rs
+++ b/src/lair/bytecode.rs
@@ -32,6 +32,8 @@ pub enum Op<F> {
     Store(List<usize>),
     /// `Load(len, y)` extends the stack with the `len` values that is pointed by `y`
     Load(usize, usize),
+    /// `Hash([x, ...])` extends the stack with the hash of `x, ...`
+    Hash(List<usize>),
     /// `Debug(s)` emits debug message `s`
     Debug(&'static str),
 }
@@ -42,6 +44,7 @@ pub enum Op<F> {
 pub struct Block<F> {
     pub(crate) ops: List<Op<F>>,
     pub(crate) ctrl: Ctrl<F>,
+    pub(crate) return_idents: List<usize>,
 }
 
 /// Encodes the logical flow of a Lair program

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -6,6 +6,7 @@ use std::slice::Iter;
 use super::{
     bytecode::{Block, Ctrl, Func, Op},
     chip::FuncChip,
+    hasher::Hasher,
     toplevel::Toplevel,
     List,
 };
@@ -82,12 +83,15 @@ pub fn mem_load<F: PrimeField>(mem: &mut [MemMap<F>], len: usize, ptr: F) -> &[F
 
 impl<F: Field> QueryRecord<F> {
     #[inline]
-    pub fn new(toplevel: &Toplevel<F>) -> Self {
+    pub fn new<H: Hasher<F>>(toplevel: &Toplevel<F, H>) -> Self {
         Self::new_with_init_mem(toplevel, mem_init())
     }
 
     #[inline]
-    pub fn new_with_init_mem(toplevel: &Toplevel<F>, mem_queries: Vec<MemMap<F>>) -> Self {
+    pub fn new_with_init_mem<H: Hasher<F>>(
+        toplevel: &Toplevel<F, H>,
+        mem_queries: Vec<MemMap<F>>,
+    ) -> Self {
         let func_queries = vec![FxIndexMap::default(); toplevel.size()];
         let inv_func_queries = toplevel
             .map
@@ -114,11 +118,16 @@ impl<F: Field> QueryRecord<F> {
 
     /// Injects new queries for a function referenced by name. If a query is already present, do nothing.
     /// Otherwise, add it with multiplicity zero. Further, if the function is invertible, add the query
-    /// to the `inv_func_queries` as well.
-    pub fn inject_queries<I: Into<List<F>>, O: Into<List<F>>, T: IntoIterator<Item = (I, O)>>(
+    /// to its `inv_func_queries` as well.
+    pub fn inject_queries<
+        I: Into<List<F>>,
+        O: Into<List<F>>,
+        T: IntoIterator<Item = (I, O)>,
+        H: Hasher<F>,
+    >(
         &mut self,
         name: &'static str,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         new_queries_data: T,
     ) {
         let func = toplevel.get_by_name(name).expect("Unknown Func");
@@ -179,9 +188,9 @@ impl<F: Field + Ord> QueryRecord<F> {
 }
 
 impl<F: PrimeField> QueryRecord<F> {
-    fn record_event_and_return(
+    fn record_event_and_return<H: Hasher<F>>(
         &mut self,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         func_idx: usize,
         args: List<F>,
     ) -> List<F> {
@@ -200,7 +209,7 @@ impl<F: PrimeField> QueryRecord<F> {
     }
 }
 
-impl<'a, F: PrimeField> FuncChip<'a, F> {
+impl<'a, F: PrimeField, H: Hasher<F>> FuncChip<'a, F, H> {
     pub fn execute(&self, args: List<F>, queries: &mut QueryRecord<F>) {
         let index = self.func.index;
         let toplevel = self.toplevel;
@@ -235,16 +244,21 @@ enum Continuation<F> {
 }
 
 impl<F: PrimeField> Func<F> {
-    fn execute(&self, args: &[F], toplevel: &Toplevel<F>, queries: &mut QueryRecord<F>) -> List<F> {
+    fn execute<H: Hasher<F>>(
+        &self,
+        args: &[F],
+        toplevel: &Toplevel<F, H>,
+        queries: &mut QueryRecord<F>,
+    ) -> List<F> {
         let frame = &mut args.into();
         assert_eq!(self.input_size(), args.len(), "Argument mismatch");
         self.body().execute(frame, toplevel, queries)
     }
 
-    pub fn execute_iter(
+    pub fn execute_iter<H: Hasher<F>>(
         &self,
         args: &[F],
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         queries: &mut QueryRecord<F>,
     ) -> List<F> {
         assert_eq!(self.input_size(), args.len(), "Argument mismatch");
@@ -280,10 +294,10 @@ impl<F: PrimeField> Func<F> {
 }
 
 impl<F: PrimeField> Block<F> {
-    fn execute(
+    fn execute<H: Hasher<F>>(
         &self,
         map: &mut VarMap<F>,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         queries: &mut QueryRecord<F>,
     ) -> List<F> {
         self.ops
@@ -292,11 +306,11 @@ impl<F: PrimeField> Block<F> {
         self.ctrl.execute(map, toplevel, queries)
     }
 
-    fn execute_step<'a>(
+    fn execute_step<'a, H: Hasher<F>>(
         &'a self,
         map: VarMap<F>,
         stack: &mut Stack<'a, F>,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         queries: &mut QueryRecord<F>,
     ) -> Continuation<F> {
         let ops = self.ops.iter();
@@ -306,10 +320,10 @@ impl<F: PrimeField> Block<F> {
 }
 
 impl<F: PrimeField> Ctrl<F> {
-    fn execute(
+    fn execute<H: Hasher<F>>(
         &self,
         map: &mut VarMap<F>,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         queries: &mut QueryRecord<F>,
     ) -> List<F> {
         match self {
@@ -349,11 +363,11 @@ impl<F: PrimeField> Ctrl<F> {
         }
     }
 
-    fn execute_step<'a>(
+    fn execute_step<'a, H: Hasher<F>>(
         &'a self,
         map: VarMap<F>,
         stack: &mut Stack<'a, F>,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         queries: &mut QueryRecord<F>,
     ) -> Continuation<F> {
         match self {
@@ -398,7 +412,12 @@ impl<F: PrimeField> Ctrl<F> {
 }
 
 impl<F: PrimeField> Op<F> {
-    fn execute(&self, map: &mut VarMap<F>, toplevel: &Toplevel<F>, queries: &mut QueryRecord<F>) {
+    fn execute<H: Hasher<F>>(
+        &self,
+        map: &mut VarMap<F>,
+        toplevel: &Toplevel<F, H>,
+        queries: &mut QueryRecord<F>,
+    ) {
         match self {
             Op::Const(c) => {
                 map.push(*c);
@@ -449,16 +468,21 @@ impl<F: PrimeField> Op<F> {
                 let args = queries.load(*len, *ptr);
                 map.extend(args);
             }
+            Op::Hash(inp) => {
+                let args: List<_> = inp.iter().map(|a| map[*a]).collect();
+                let hasher = &toplevel.hasher;
+                map.extend(hasher.hash(&args).iter());
+            }
             Op::Debug(s) => println!("{}", s),
         }
     }
 
-    fn execute_step<'a>(
+    fn execute_step<'a, H: Hasher<F>>(
         mut ops: Iter<'a, Self>,
         ctrl: &'a Ctrl<F>,
         mut map: VarMap<F>,
         stack: &mut Stack<'a, F>,
-        toplevel: &Toplevel<F>,
+        toplevel: &Toplevel<F, H>,
         queries: &mut QueryRecord<F>,
     ) -> Continuation<F> {
         while let Some(op) = ops.next() {
@@ -523,6 +547,11 @@ impl<F: PrimeField> Op<F> {
                         return Continuation::Apply(*index, args);
                     }
                 }
+                Op::Hash(inp) => {
+                    let args: List<_> = inp.iter().map(|a| map[*a]).collect();
+                    let hasher = &toplevel.hasher;
+                    map.extend(hasher.hash(&args).iter());
+                }
             }
         }
         ctrl.execute_step(map, stack, toplevel, queries)
@@ -533,7 +562,10 @@ impl<F: PrimeField> Op<F> {
 mod tests {
     use crate::{
         func,
-        lair::{demo_toplevel, execute::QueryRecord, field_from_u32, toplevel::Toplevel, List},
+        lair::{
+            demo_toplevel, execute::QueryRecord, field_from_u32, hasher::LurkHasher,
+            toplevel::Toplevel, List,
+        },
     };
 
     use p3_baby_bear::BabyBear as F;
@@ -541,7 +573,7 @@ mod tests {
 
     #[test]
     fn lair_execute_test() {
-        let toplevel = demo_toplevel::<_>();
+        let toplevel = demo_toplevel::<_, LurkHasher>();
 
         let factorial = toplevel.get_by_name("factorial").unwrap();
         let args = &[F::from_canonical_u32(5)];
@@ -565,7 +597,7 @@ mod tests {
 
     #[test]
     fn lair_execute_iter_test() {
-        let toplevel = demo_toplevel::<_>();
+        let toplevel = demo_toplevel::<_, LurkHasher>();
 
         let fib = toplevel.get_by_name("fib").unwrap();
         let args = &[F::from_canonical_u32(100000)];
@@ -583,7 +615,7 @@ mod tests {
                 return n
             }
         );
-        let toplevel = Toplevel::new(&[test_e]);
+        let toplevel = Toplevel::<_, LurkHasher>::new(&[test_e]);
         let test = toplevel.get_by_name("test").unwrap();
         let args = &[F::from_canonical_u32(20), F::from_canonical_u32(4)];
         let record = &mut QueryRecord::new(&toplevel);
@@ -602,7 +634,7 @@ mod tests {
                 return x
             }
         );
-        let toplevel = Toplevel::new(&[test_e]);
+        let toplevel = Toplevel::<_, LurkHasher>::new(&[test_e]);
         let test = toplevel.get_by_name("test").unwrap();
         let args = &[F::from_canonical_u32(10)];
         let record = &mut QueryRecord::new(&toplevel);
@@ -633,7 +665,7 @@ mod tests {
                 return (a0, a1, a2, a3, x)
             }
         );
-        let toplevel = Toplevel::<F>::new(&[polynomial_e, inverse_e]);
+        let toplevel = Toplevel::<F, LurkHasher>::new(&[polynomial_e, inverse_e]);
         let polynomial = toplevel.get_by_name("polynomial").unwrap();
         let inverse = toplevel.get_by_name("inverse").unwrap();
         let args = [1, 3, 5, 7, 20]
@@ -668,7 +700,7 @@ mod tests {
                 return (a_b, b_c, c_d)
             }
         );
-        let toplevel = Toplevel::new(&[test1_e, test2_e]);
+        let toplevel = Toplevel::<_, LurkHasher>::new(&[test1_e, test2_e]);
         let test = toplevel.get_by_name("test1").unwrap();
         let f = F::from_canonical_u32;
         let args = &[f(1), f(2), f(3), f(4), f(5), f(6), f(7)];

--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -77,6 +77,8 @@ pub enum OpE<F> {
     /// `Slice([x, ...], [y, ...])` matches the pattern `[x, ...]` against the values
     /// formed by `[y, ...]`
     Slice(VarList, VarList),
+    /// `Hash([x, ...], [y, ...])` binds `x, ...` to the hash of `y, ...`
+    Hash(VarList, VarList),
     /// `Debug(s)` emits debug message `s`
     Debug(&'static str),
 }

--- a/src/lair/hasher.rs
+++ b/src/lair/hasher.rs
@@ -1,17 +1,31 @@
+use p3_air::AirBuilder;
 use p3_baby_bear::BabyBear;
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::Permutation;
 
-use crate::poseidon::config::{
-    BabyBearConfig24, BabyBearConfig32, BabyBearConfig48, InternalDiffusion, PoseidonConfig,
+use crate::poseidon::{
+    config::{
+        BabyBearConfig24, BabyBearConfig32, BabyBearConfig48, InternalDiffusion, PoseidonConfig,
+    },
+    wide::{air::eval_input, columns::Poseidon2Cols, trace::populate_witness},
 };
 
-use super::List;
+pub trait Hasher<F>: Default + Sync {
+    fn img_size(&self) -> usize;
 
-pub trait Hasher: Default {
-    type F;
+    fn hash(&self, preimg: &[F]) -> Vec<F>;
 
-    fn hash(&self, preimg: &[Self::F]) -> List<Self::F>;
+    fn populate_witness(&self, preimg: &[F], witness: &mut [F]) -> Vec<F>;
+
+    fn witness_size(&self, preimg_size: usize) -> usize;
+
+    fn eval_preimg<AB: AirBuilder<F = F>>(
+        &self,
+        builder: &mut AB,
+        preimg: Vec<AB::Expr>,
+        witness: &[AB::Var],
+        is_real: AB::Expr,
+    ) -> Vec<AB::Var>;
 }
 
 pub struct LurkHasher {
@@ -36,9 +50,6 @@ pub struct LurkHasher {
         48,
         7,
     >,
-    // chip_24_8: Poseidon2Chip<BabyBearConfig24>,
-    // chip_32_8: Poseidon2Chip<BabyBearConfig32>,
-    // chip_48_8: Poseidon2Chip<BabyBearConfig48>,
 }
 
 impl Default for LurkHasher {
@@ -50,26 +61,68 @@ impl Default for LurkHasher {
             hasher_24_8,
             hasher_32_8,
             hasher_48_8,
-            // chip_24_8,
-            // chip_32_8,
-            // chip_48_8,
         }
     }
 }
 
-impl Hasher for LurkHasher {
-    type F = BabyBear;
+macro_rules! sized {
+    ($vector:ident) => {
+        $vector.try_into().unwrap()
+    };
+}
 
-    fn hash(&self, preimg: &[Self::F]) -> List<Self::F> {
+impl Hasher<BabyBear> for LurkHasher {
+    #[inline]
+    fn img_size(&self) -> usize {
+        8
+    }
+
+    fn hash(&self, preimg: &[BabyBear]) -> Vec<BabyBear> {
         macro_rules! hash_with {
             ($name:ident) => {
-                self.$name.permute(preimg.try_into().unwrap())[..8].into()
+                self.$name.permute(sized!(preimg))[..self.img_size()].into()
             };
         }
         match preimg.len() {
             24 => hash_with!(hasher_24_8),
             32 => hash_with!(hasher_32_8),
             48 => hash_with!(hasher_48_8),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn populate_witness(&self, preimg: &[BabyBear], witness: &mut [BabyBear]) -> Vec<BabyBear> {
+        match preimg.len() {
+            24 => populate_witness::<BabyBearConfig24, 24>(sized!(preimg), witness).into(),
+            32 => populate_witness::<BabyBearConfig32, 32>(sized!(preimg), witness).into(),
+            48 => populate_witness::<BabyBearConfig48, 48>(sized!(preimg), witness).into(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn witness_size(&self, preimg_size: usize) -> usize {
+        match preimg_size {
+            24 => Poseidon2Cols::<BabyBear, BabyBearConfig24, 24>::num_cols(),
+            32 => Poseidon2Cols::<BabyBear, BabyBearConfig32, 32>::num_cols(),
+            48 => Poseidon2Cols::<BabyBear, BabyBearConfig48, 48>::num_cols(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn eval_preimg<AB: AirBuilder<F = BabyBear>>(
+        &self,
+        builder: &mut AB,
+        preimg: Vec<AB::Expr>,
+        witness: &[AB::Var],
+        is_real: AB::Expr,
+    ) -> Vec<AB::Var> {
+        match preimg.len() {
+            24 => eval_input::<AB, BabyBearConfig24, 24>(builder, sized!(preimg), witness, is_real)
+                .into(),
+            32 => eval_input::<AB, BabyBearConfig32, 32>(builder, sized!(preimg), witness, is_real)
+                .into(),
+            48 => eval_input::<AB, BabyBearConfig48, 48>(builder, sized!(preimg), witness, is_real)
+                .into(),
             _ => unimplemented!(),
         }
     }

--- a/src/lair/macros.rs
+++ b/src/lair/macros.rs
@@ -141,6 +141,20 @@ macro_rules! block {
         let $tgt = $crate::var!($tgt $(, $size)?);
         $crate::block!({ $($tail)* }, $ops)
     }};
+    ({ let $tgt:ident $(: [$size:expr])? = hash($($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let out = [$crate::var!($tgt $(, $size)?)].into();
+        let inp = [$($arg),*].into();
+        $ops.push($crate::lair::expr::OpE::Hash(out, inp));
+        let $tgt = $crate::var!($tgt $(, $size)?);
+        $crate::block!({ $($tail)* }, $ops)
+    }};
+    ({ let ($($tgt:ident $(: [$size:expr])?),*) = hash($($arg:ident),*); $($tail:tt)+ }, $ops:expr) => {{
+        let out = [$($crate::var!($tgt $(, $size)?)),*].into();
+        let inp = [$($arg),*].into();
+        $ops.push($crate::lair::expr::OpE::Hash(out, inp));
+        $(let $tgt = $crate::var!($tgt $(, $size)?);)*
+        $crate::block!({ $($tail)* }, $ops)
+    }};
     ({ debug!($s:literal); $($tail:tt)+ }, $ops:expr) => {{
         $ops.push($crate::lair::expr::OpE::Debug($s));
         $crate::block!({ $($tail)* }, $ops)

--- a/src/lair/memory.rs
+++ b/src/lair/memory.rs
@@ -84,6 +84,7 @@ impl MemChip {
 #[cfg(test)]
 mod tests {
     use crate::air::debug::debug_constraints_collecting_queries;
+    use crate::lair::hasher::LurkHasher;
     use crate::{
         func,
         lair::{chip::FuncChip, toplevel::Toplevel},
@@ -104,7 +105,7 @@ mod tests {
             let (_x, y, _z) = load(ptr1);
             return (ptr2, y)
         });
-        let toplevel = Toplevel::<F>::new(&[func_e]);
+        let toplevel = Toplevel::<F, LurkHasher>::new(&[func_e]);
         let test_chip = FuncChip::from_name("test", &toplevel);
         let queries = &mut QueryRecord::new(&toplevel);
         test_chip.execute([].into(), queries);

--- a/src/lair/mod.rs
+++ b/src/lair/mod.rs
@@ -1,3 +1,4 @@
+use hasher::Hasher;
 use p3_field::Field;
 
 use crate::func;
@@ -46,7 +47,7 @@ pub(crate) fn field_from_i32<F: p3_field::AbstractField>(i: i32) -> F {
 pub type List<T> = Box<[T]>;
 
 #[allow(dead_code)]
-pub(crate) fn demo_toplevel<F: Field + Ord>() -> Toplevel<F> {
+pub(crate) fn demo_toplevel<F: Field + Ord, H: Hasher<F>>() -> Toplevel<F, H> {
     let factorial_e = func!(
     fn factorial(n): [1] {
         let one = 1;
@@ -103,5 +104,5 @@ pub(crate) fn demo_toplevel<F: Field + Ord>() -> Toplevel<F> {
         return res
     });
 
-    Toplevel::<F>::new(&[factorial_e, fib_e, even_e, odd_e])
+    Toplevel::new(&[factorial_e, fib_e, even_e, odd_e])
 }

--- a/src/lair/toplevel.rs
+++ b/src/lair/toplevel.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
 
-use super::{bytecode::*, expr::*, map::Map, List, Name};
+use super::{bytecode::*, expr::*, hasher::Hasher, map::Map, List, Name};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Toplevel<F> {
+pub struct Toplevel<F, H: Hasher<F>> {
     pub(crate) map: Map<Name, Func<F>>,
+    pub(crate) hasher: H,
 }
 
 pub(crate) struct FuncInfo {
@@ -12,7 +13,7 @@ pub(crate) struct FuncInfo {
     output_size: usize,
 }
 
-impl<F: Clone + Ord> Toplevel<F> {
+impl<F: Clone + Ord, H: Hasher<F>> Toplevel<F, H> {
     pub fn new(funcs: &[FuncE<F>]) -> Self {
         let ordered_funcs = Map::from_vec(funcs.iter().map(|func| (func.name, func)).collect());
         let info_vec = ordered_funcs
@@ -25,19 +26,20 @@ impl<F: Clone + Ord> Toplevel<F> {
                 (*name, func_info)
             })
             .collect();
+        let hasher = H::default();
         let info_map = Map::from_vec_unsafe(info_vec);
         let map = Map::from_vec_unsafe(
             ordered_funcs
                 .iter()
                 .enumerate()
-                .map(|(i, (name, func))| (*name, func.check_and_link(i, &info_map)))
+                .map(|(i, (name, func))| (*name, func.check_and_link(i, &info_map, &hasher)))
                 .collect(),
         );
-        Toplevel { map }
+        Toplevel { map, hasher }
     }
 }
 
-impl<F> Toplevel<F> {
+impl<F, H: Hasher<F>> Toplevel<F, H> {
     #[inline]
     pub fn get_by_index(&self, i: usize) -> Option<&Func<F>> {
         self.map.get_index(i).map(|(_, func)| func)
@@ -97,6 +99,7 @@ struct CheckCtx<'a> {
     var_index: usize,
     block_ident: usize,
     return_ident: usize,
+    return_idents: Vec<usize>,
     return_size: usize,
     bind_map: BindMap,
     used_map: UsedMap,
@@ -117,11 +120,17 @@ impl<'a> CheckCtx<'a> {
 impl<F: Clone + Ord> FuncE<F> {
     /// Checks if a named `Func` is correct, and produces an index-based `Func`
     /// by replacing names with indices
-    fn check_and_link(&self, func_index: usize, info_map: &Map<Name, FuncInfo>) -> Func<F> {
+    fn check_and_link<H: Hasher<F>>(
+        &self,
+        func_index: usize,
+        info_map: &Map<Name, FuncInfo>,
+        hasher: &H,
+    ) -> Func<F> {
         let ctx = &mut CheckCtx {
             var_index: 0,
             block_ident: 0,
             return_ident: 0,
+            return_idents: vec![],
             return_size: self.output_size,
             bind_map: BTreeMap::new(),
             used_map: BTreeMap::new(),
@@ -130,7 +139,7 @@ impl<F: Clone + Ord> FuncE<F> {
         self.input_params.iter().for_each(|var| {
             bind_new(var, ctx);
         });
-        let body = self.body.check_and_link(ctx);
+        let body = self.body.check_and_link(ctx, hasher);
         for ((var, _), used) in ctx.used_map.iter() {
             let ch = var.name.chars().next().expect("Empty var name");
             assert!(
@@ -150,7 +159,7 @@ impl<F: Clone + Ord> FuncE<F> {
 }
 
 impl<F: Clone + Ord> BlockE<F> {
-    fn check_and_link(&self, ctx: &mut CheckCtx<'_>) -> Block<F> {
+    fn check_and_link<H: Hasher<F>>(&self, ctx: &mut CheckCtx<'_>, hasher: &H) -> Block<F> {
         let mut ops = Vec::new();
         for op in self.ops.iter() {
             match op {
@@ -283,16 +292,38 @@ impl<F: Clone + Ord> BlockE<F> {
                         i += pat.size;
                     }
                 }
+                OpE::Hash(img, preimg) => {
+                    assert_eq!(img.total_size(), hasher.img_size());
+                    let preimg: List<_> = preimg
+                        .iter()
+                        .flat_map(|a| use_var(a, ctx).to_vec())
+                        .collect();
+                    let mut i = 0;
+                    for v in img.as_slice() {
+                        let idxs = preimg[i..i + v.size].into();
+                        bind(v, idxs, ctx);
+                        i += v.size;
+                    }
+                    ops.push(Op::Hash(preimg));
+                }
             }
         }
         let ops = ops.into();
-        let ctrl = self.ctrl.check_and_link(ctx);
-        Block { ctrl, ops }
+        let saved_return_idents = std::mem::take(&mut ctx.return_idents);
+        let ctrl = self.ctrl.check_and_link(ctx, hasher);
+        let block_return_idents = std::mem::take(&mut ctx.return_idents);
+        ctx.return_idents = saved_return_idents;
+        ctx.return_idents.extend(&block_return_idents);
+        Block {
+            ops,
+            ctrl,
+            return_idents: block_return_idents.into(),
+        }
     }
 }
 
 impl<F: Clone + Ord> CtrlE<F> {
-    fn check_and_link(&self, ctx: &mut CheckCtx<'_>) -> Ctrl<F> {
+    fn check_and_link<H: Hasher<F>>(&self, ctx: &mut CheckCtx<'_>, hasher: &H) -> Ctrl<F> {
         match &self {
             CtrlE::Return(return_vars) => {
                 let total_size = return_vars.total_size();
@@ -306,6 +337,7 @@ impl<F: Clone + Ord> CtrlE<F> {
                     .flat_map(|arg| use_var(arg, ctx).to_vec())
                     .collect();
                 let ctrl = Ctrl::Return(ctx.return_ident, return_vec);
+                ctx.return_idents.push(ctx.return_ident);
                 ctx.return_ident += 1;
                 ctrl
             }
@@ -316,14 +348,14 @@ impl<F: Clone + Ord> CtrlE<F> {
                 for (f, block) in cases.branches.iter() {
                     ctx.block_ident += 1;
                     let state = ctx.save_bind_state();
-                    let block = block.check_and_link(ctx);
+                    let block = block.check_and_link(ctx, hasher);
                     ctx.restore_bind_state(state);
                     vec.push((f.clone(), block))
                 }
                 let branches = Map::from_vec(vec);
                 let default = cases.default.as_ref().map(|def| {
                     ctx.block_ident += 1;
-                    def.check_and_link(ctx).into()
+                    def.check_and_link(ctx, hasher).into()
                 });
                 let cases = Cases { branches, default };
                 Ctrl::Match(t, cases)
@@ -336,14 +368,14 @@ impl<F: Clone + Ord> CtrlE<F> {
                     assert_eq!(fs.len(), size, "Pattern must have size {size}");
                     ctx.block_ident += 1;
                     let state = ctx.save_bind_state();
-                    let block = block.check_and_link(ctx);
+                    let block = block.check_and_link(ctx, hasher);
                     ctx.restore_bind_state(state);
                     vec.push((fs.clone(), block))
                 }
                 let branches = Map::from_vec(vec);
                 let default = cases.default.as_ref().map(|def| {
                     ctx.block_ident += 1;
-                    def.check_and_link(ctx).into()
+                    def.check_and_link(ctx, hasher).into()
                 });
                 let cases = Cases { branches, default };
                 Ctrl::MatchMany(vars, cases)
@@ -353,11 +385,11 @@ impl<F: Clone + Ord> CtrlE<F> {
 
                 ctx.block_ident += 1;
                 let state = ctx.save_bind_state();
-                let true_block = true_block.check_and_link(ctx);
+                let true_block = true_block.check_and_link(ctx, hasher);
                 ctx.restore_bind_state(state);
 
                 ctx.block_ident += 1;
-                let false_block = false_block.check_and_link(ctx);
+                let false_block = false_block.check_and_link(ctx, hasher);
 
                 if b.size != 1 {
                     Ctrl::IfMany(vars, true_block.into(), false_block.into())

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -2,20 +2,20 @@ use p3_field::{Field, PrimeField};
 
 use crate::{
     func,
-    lair::{expr::FuncE, toplevel::Toplevel},
+    lair::{expr::FuncE, hasher::Hasher, toplevel::Toplevel},
 };
 
 use super::{
     memory::Memory,
-    zstore::{Hasher, Tag, ZStore},
+    zstore::{HasherTemp, Tag, ZStore},
 };
 
 /// Creates a `Toplevel` with the functions used for Lurk evaluation
 #[inline]
-pub fn build_lurk_toplevel<F: PrimeField, H: Hasher<F = F>>(
-    mem: &mut Memory<F, H>,
-    store: &ZStore<F, H>,
-) -> Toplevel<F> {
+pub fn build_lurk_toplevel<F: PrimeField, HT: HasherTemp<F = F>, H: Hasher<F>>(
+    mem: &mut Memory<F, HT>,
+    store: &ZStore<F, HT>,
+) -> Toplevel<F, H> {
     Toplevel::new(&[
         eval(mem, store),
         eval_unop(mem, store),
@@ -164,25 +164,23 @@ pub fn egress<F: PrimeField>() -> FuncE<F> {
 
 pub fn hash_32_8<F: PrimeField>() -> FuncE<F> {
     func!(
-        invertible fn hash_32_8(_preimg: [32]): [8] {
-            let zero = 0;
-            let (dig: [8]) = (zero, zero, zero, zero, zero, zero, zero, zero);
-            return dig
+        invertible fn hash_32_8(preimg: [32]): [8] {
+            let (img: [8]) = hash(preimg);
+            return img
         }
     )
 }
 
 pub fn hash_48_8<F: PrimeField>() -> FuncE<F> {
     func!(
-        fn hash_48_8(_preimg: [48]): [8] {
-            let zero = 0;
-            let (dig: [8]) = (zero, zero, zero, zero, zero, zero, zero, zero);
-            return dig
+        invertible fn hash_48_8(preimg: [48]): [8] {
+            let (img: [8]) = hash(preimg);
+            return img
         }
     )
 }
 
-pub fn eval<F: PrimeField, H: Hasher<F = F>>(
+pub fn eval<F: PrimeField, H: HasherTemp<F = F>>(
     mem: &mut Memory<F, H>,
     store: &ZStore<F, H>,
 ) -> FuncE<F> {
@@ -465,7 +463,7 @@ pub fn eval<F: PrimeField, H: Hasher<F = F>>(
     )
 }
 
-pub fn car_cdr<F: PrimeField, H: Hasher<F = F>>(
+pub fn car_cdr<F: PrimeField, H: HasherTemp<F = F>>(
     mem: &mut Memory<F, H>,
     store: &ZStore<F, H>,
 ) -> FuncE<F> {
@@ -515,7 +513,7 @@ pub fn car_cdr<F: PrimeField, H: Hasher<F = F>>(
     )
 }
 
-pub fn eval_binop_num<F: PrimeField, H: Hasher<F = F>>(
+pub fn eval_binop_num<F: PrimeField, H: HasherTemp<F = F>>(
     mem: &mut Memory<F, H>,
     store: &ZStore<F, H>,
 ) -> FuncE<F> {
@@ -599,7 +597,7 @@ pub fn eval_binop_num<F: PrimeField, H: Hasher<F = F>>(
     )
 }
 
-pub fn eval_binop_misc<F: PrimeField, H: Hasher<F = F>>(
+pub fn eval_binop_misc<F: PrimeField, H: HasherTemp<F = F>>(
     mem: &mut Memory<F, H>,
     store: &ZStore<F, H>,
 ) -> FuncE<F> {
@@ -684,7 +682,7 @@ pub fn eval_binop_misc<F: PrimeField, H: Hasher<F = F>>(
     )
 }
 
-pub fn eval_unop<F: PrimeField, H: Hasher<F = F>>(
+pub fn eval_unop<F: PrimeField, H: HasherTemp<F = F>>(
     mem: &mut Memory<F, H>,
     store: &ZStore<F, H>,
 ) -> FuncE<F> {
@@ -1022,7 +1020,9 @@ mod test {
 
     use crate::{
         air::debug::debug_constraints_collecting_queries,
-        lair::{chip::FuncChip, execute::QueryRecord, toplevel::Toplevel, List},
+        lair::{
+            chip::FuncChip, execute::QueryRecord, hasher::LurkHasher, toplevel::Toplevel, List,
+        },
         lurk::{
             reader::{read, ReadData},
             state::State,
@@ -1065,7 +1065,12 @@ mod test {
                 return (res_tag, res)
             }
         );
-        let toplevel = Toplevel::new(&[list_lookup, to_env_lookup, env_lookup(), list_to_env()]);
+        let toplevel = Toplevel::<_, LurkHasher>::new(&[
+            list_lookup,
+            to_env_lookup,
+            env_lookup(),
+            list_to_env(),
+        ]);
         let list_lookup = FuncChip::from_name("list_lookup", &toplevel);
         let to_env_lookup = FuncChip::from_name("to_env_lookup", &toplevel);
 
@@ -1102,7 +1107,7 @@ mod test {
 
         let mem = &mut Memory::init();
         let store = &ZStore::<F, PoseidonBabyBearHasher>::new();
-        let toplevel = &build_lurk_toplevel(mem, store);
+        let toplevel = &build_lurk_toplevel::<_, _, LurkHasher>(mem, store);
         let queries = &mut QueryRecord::new_with_init_mem(toplevel, take(&mut mem.map));
 
         // Chips
@@ -1209,13 +1214,15 @@ mod test {
     }
 
     #[test]
-    fn test_ingress_egress_roundtrip() {
-        let toplevel = Toplevel::<F>::new(&[ingress(), egress(), hash_32_8(), hash_48_8()]);
+    fn test_ingress_egress() {
+        let toplevel =
+            Toplevel::<F, LurkHasher>::new(&[ingress(), egress(), hash_32_8(), hash_48_8()]);
 
         let ingress_chip = FuncChip::from_name("ingress", &toplevel);
         let egress_chip = FuncChip::from_name("egress", &toplevel);
+        let hash_32_8_chip = FuncChip::from_name("hash_32_8", &toplevel);
 
-        let assert_ingress_egress_roundtrip = |code| {
+        let assert_ingress_egress_correctness = |code| {
             let ReadData {
                 tag,
                 digest,
@@ -1245,21 +1252,24 @@ mod test {
                 .unwrap()
                 .output;
 
-            assert_eq!(egress_out, &digest);
+            assert_eq!(egress_out, &digest, "ingress -> egress doesn't roundtrip");
+
+            let hash_32_8_trace = hash_32_8_chip.generate_trace_parallel(queries);
+            debug_constraints_collecting_queries(&hash_32_8_chip, &[], &hash_32_8_trace);
         };
 
-        assert_ingress_egress_roundtrip("~()");
-        assert_ingress_egress_roundtrip("~:()");
-        assert_ingress_egress_roundtrip("()");
-        assert_ingress_egress_roundtrip("'c'");
-        assert_ingress_egress_roundtrip("5u64");
-        assert_ingress_egress_roundtrip("\"\"");
-        assert_ingress_egress_roundtrip("\"a\"");
-        assert_ingress_egress_roundtrip("\"test string\"");
-        assert_ingress_egress_roundtrip(".a");
-        assert_ingress_egress_roundtrip("TestSymbol");
-        assert_ingress_egress_roundtrip(":keyword");
-        assert_ingress_egress_roundtrip("(+ 1 2)");
-        assert_ingress_egress_roundtrip("(a 'b c)");
+        assert_ingress_egress_correctness("~()");
+        assert_ingress_egress_correctness("~:()");
+        assert_ingress_egress_correctness("()");
+        assert_ingress_egress_correctness("'c'");
+        assert_ingress_egress_correctness("5u64");
+        assert_ingress_egress_correctness("\"\"");
+        assert_ingress_egress_correctness("\"a\"");
+        assert_ingress_egress_correctness("\"test string\"");
+        assert_ingress_egress_correctness(".a");
+        assert_ingress_egress_correctness("TestSymbol");
+        assert_ingress_egress_correctness(":keyword");
+        assert_ingress_egress_correctness("(+ 1 2)");
+        assert_ingress_egress_correctness("(a 'b c)");
     }
 }

--- a/src/lurk/memory.rs
+++ b/src/lurk/memory.rs
@@ -7,7 +7,7 @@ use crate::lair::{
     List,
 };
 
-use super::zstore::{Hasher, Payload, Tag, ZExpr, ZPtr, ZStore, DIGEST};
+use super::zstore::{HasherTemp, Payload, Tag, ZExpr, ZPtr, ZStore, DIGEST};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MPtr<F> {
@@ -22,7 +22,7 @@ pub struct Memory<F, H> {
     pub _p: PhantomData<H>,
 }
 
-impl<F: PrimeField, H: Hasher<F = F>> Memory<F, H> {
+impl<F: PrimeField, H: HasherTemp<F = F>> Memory<F, H> {
     pub fn init() -> Self {
         let map = mem_init();
         let cache = BTreeMap::new();

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -25,7 +25,7 @@ use super::{
 pub const DIGEST: usize = 8;
 pub const WIDTH: usize = 24;
 
-pub trait Hasher {
+pub trait HasherTemp {
     type F: Field;
     fn hash(fs: &[Self::F]) -> [Self::F; DIGEST] {
         let mut state = [Self::F::zero(); WIDTH];
@@ -161,12 +161,12 @@ pub enum ZExpr<F> {
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ZStore<F: Ord + Clone, H: Hasher<F = F>> {
+pub struct ZStore<F: Ord + Clone, H: HasherTemp<F = F>> {
     pub(crate) map: FrozenBTreeMap<ZPtr<F>, Box<ZExpr<F>>>,
     _p: PhantomData<H>,
 }
 
-impl<F: Field + Ord, H: Hasher<F = F>> ZStore<F, H> {
+impl<F: Field + Ord, H: HasherTemp<F = F>> ZStore<F, H> {
     pub fn new() -> Self {
         ZStore {
             map: FrozenBTreeMap::new(),
@@ -344,7 +344,7 @@ impl<F: Field + Ord, H: Hasher<F = F>> ZStore<F, H> {
 #[derive(Clone)]
 pub struct PoseidonBabyBearHasher;
 
-impl Hasher for PoseidonBabyBearHasher {
+impl HasherTemp for PoseidonBabyBearHasher {
     type F = F;
     fn hash_aux(state: &mut [F; WIDTH]) {
         let mut rng = Xoroshiro128Plus::seed_from_u64(1);


### PR DESCRIPTION
To realize a hash operator for Lair, the `Hasher` trait had to be extended in order to provide enough data for Air-related impls.

`Op::Hash` needs access to a `is_real` for the block it belongs to. `is_real` can be defined as the sum of all `local.sel[ident]` for every `ident` in `Ctrl::Return(ident, _)` that block (transitively) contains.

In order to accomplish the above, `return_idents: List<usize>` was added as a new attribute of `Block`, computed during compilation.