### PR TITLE
chore: cleanup macros and simplify #99

### DIFF
--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -47,7 +47,7 @@ pub enum OpE<F> {
     /// `Const(var, x)` binds `var` to the constant `x`
     Const(Var, F),
     /// `Array(var, arr)` binds `var` to the constant array `arr`
-    Array(Var, Vec<F>),
+    Array(Var, List<F>),
     /// `Add(x, y, z)` binds `x` to the sum of the bindings of `y` and `z`
     Add(Var, Var, Var),
     /// `Sub(x, y, z)` binds `x` to the subtraction of the bindings of `y` and `z`

--- a/src/lair/mod.rs
+++ b/src/lair/mod.rs
@@ -29,19 +29,8 @@ impl std::fmt::Display for Name {
 }
 
 #[inline]
-#[allow(dead_code)]
 pub(crate) fn field_from_u32<F: p3_field::AbstractField>(i: u32) -> F {
     F::from_canonical_u32(i)
-}
-
-#[inline]
-#[allow(dead_code)]
-pub(crate) fn field_from_i32<F: p3_field::AbstractField>(i: i32) -> F {
-    if i < 0 {
-        -F::from_canonical_u32((-i).try_into().unwrap())
-    } else {
-        F::from_canonical_u32(i.try_into().unwrap())
-    }
 }
 
 pub type List<T> = Box<[T]>;

--- a/src/lair/toplevel.rs
+++ b/src/lair/toplevel.rs
@@ -170,7 +170,7 @@ impl<F: Clone + Ord> BlockE<F> {
                 }
                 OpE::Array(tgt, fs) => {
                     assert_eq!(tgt.size, fs.len());
-                    for f in fs {
+                    for f in fs.iter() {
                         ops.push(Op::Const(f.clone()));
                     }
                     bind_new(tgt, ctx);

--- a/src/lurk/reader.rs
+++ b/src/lurk/reader.rs
@@ -12,7 +12,7 @@ use super::{
         syntax::{parse_space, parse_syntax},
         Span,
     },
-    state::{lurk_sym, StateRcCell, LURK_PACKAGE_NONNIL_SYMBOLS_NAMES},
+    state::{lurk_sym, StateRcCell, LURK_PACKAGE_SYMBOLS_NAMES},
     symbol::Symbol,
     syntax::Syntax,
     tag::Tag,
@@ -87,9 +87,10 @@ fn nil() -> &'static Symbol {
 static BUILTIN_VEC: OnceCell<Vec<Symbol>> = OnceCell::new();
 fn builtin_vec() -> &'static Vec<Symbol> {
     BUILTIN_VEC.get_or_init(|| {
-        LURK_PACKAGE_NONNIL_SYMBOLS_NAMES
-            .map(lurk_sym)
+        LURK_PACKAGE_SYMBOLS_NAMES
             .into_iter()
+            .filter(|sym| sym != &"nil")
+            .map(lurk_sym)
             .collect()
     })
 }

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -175,8 +175,7 @@ impl State {
 
         // bootstrap the lurk package
         let mut lurk_package = Package::new(root_package.intern(LURK_PACKAGE_SYMBOL_NAME));
-        lurk_package.intern("nil".to_string());
-        for symbol_name in LURK_PACKAGE_NONNIL_SYMBOLS_NAMES.iter() {
+        for symbol_name in LURK_PACKAGE_SYMBOLS_NAMES.iter() {
             lurk_package.intern((*symbol_name).to_string());
         }
 
@@ -240,7 +239,7 @@ const LURK_PACKAGE_SYMBOL_NAME: &str = "lurk";
 const USER_PACKAGE_SYMBOL_NAME: &str = "user";
 const META_PACKAGE_SYMBOL_NAME: &str = "meta";
 
-pub(crate) const LURK_PACKAGE_NONNIL_SYMBOLS_NAMES: [&str; 35] = [
+pub(crate) const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
     "atom",
     "begin",
     "car",
@@ -259,6 +258,7 @@ pub(crate) const LURK_PACKAGE_NONNIL_SYMBOLS_NAMES: [&str; 35] = [
     "lambda",
     "let",
     "letrec",
+    "nil",
     "num",
     "u64",
     "open",

--- a/src/lurk/tag.rs
+++ b/src/lurk/tag.rs
@@ -1,4 +1,4 @@
-use p3_field::Field;
+use p3_field::AbstractField;
 
 pub const EXPR_TAG_INIT: u16 = 0b0000_0000_0000_0000;
 
@@ -22,7 +22,7 @@ pub enum Tag {
 }
 
 impl Tag {
-    pub fn to_field<F: Field>(self) -> F {
+    pub fn to_field<F: AbstractField>(self) -> F {
         F::from_canonical_u16(self as u16)
     }
 }


### PR DESCRIPTION
* Remove `lurk` crate dependencies from `lair` macros
* Use optional closures to increase the expressiveness of `match`

Closes #103