### PR TITLE
feat: benchmark for compilation of Lurk's toplevel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ criterion = { workspace = true }
 name = "fib"
 harness = false
 
+[[bench]]
+name = "lurk"
+harness = false
+
 [workspace]
 members = ["examples/calculator", "examples/byte_lookup"]
 

--- a/benches/lurk.rs
+++ b/benches/lurk.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::time::Duration;
+
+use loam::{lair::hasher::LurkHasher, lurk::eval::build_lurk_toplevel};
+
+fn toplevel(c: &mut Criterion) {
+    c.bench_function("toplevel", |b| {
+        b.iter(|| {
+            build_lurk_toplevel::<LurkHasher>();
+        })
+    });
+}
+
+criterion_group! {
+    name = lurk;
+    config = Criterion::default().measurement_time(Duration::from_secs(9));
+    targets =
+        toplevel,
+}
+
+criterion_main!(lurk);

--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -3,7 +3,7 @@
 use super::{map::Map, List, Name};
 
 /// The type for variable references
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct Var {
     pub name: &'static str,
     pub size: usize,

--- a/src/lair/toplevel.rs
+++ b/src/lair/toplevel.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use rustc_hash::FxHashMap;
 
 use super::{bytecode::*, expr::*, hasher::Hasher, map::Map, List, Name};
 
@@ -57,10 +57,10 @@ impl<F, H: Hasher<F>> Toplevel<F, H> {
 }
 
 /// A map from `Var` to its compiled indices and block identifier
-type BindMap = BTreeMap<Var, (List<usize>, usize)>;
+type BindMap = FxHashMap<Var, (List<usize>, usize)>;
 
 /// A map that tells whether a `Var`, from a certain block, has been used or not
-type UsedMap = BTreeMap<(Var, usize), bool>;
+type UsedMap = FxHashMap<(Var, usize), bool>;
 
 #[inline]
 fn bind_new(var: &Var, ctx: &mut CheckCtx<'_>) {
@@ -132,8 +132,8 @@ impl<F: Clone + Ord> FuncE<F> {
             return_ident: 0,
             return_idents: vec![],
             return_size: self.output_size,
-            bind_map: BTreeMap::new(),
-            used_map: BTreeMap::new(),
+            bind_map: FxHashMap::default(),
+            used_map: FxHashMap::default(),
             info_map,
         };
         self.input_params.iter().for_each(|var| {


### PR DESCRIPTION
Extra: replace `BTreeMap` for `FxHashMap` on toplevel compilation for extra speed:
```
toplevel                time:   [1.5078 ms 1.5081 ms 1.5083 ms]                     
                        change: [-8.8364% -8.2938% -7.7731%] (p = 0.00 < 0.05)
                        Performance has improved.
```

This is almost silly, but serves for learning purposes and awareness of time costs throughout our pipeline.