### PR TITLE
feat(poseidon): use aux variables for output + fix output width

### DIFF
--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -295,10 +295,12 @@ impl<F: Field> Op<F> {
             Op::Hash(preimg) => {
                 let preimg: Vec<_> = preimg.iter().map(|a| map[*a].to_expr()).collect();
                 let hasher = &toplevel.hasher;
+                let img_size = hasher.img_size();
+                let img_vars = local.next_n_aux(index, img_size);
                 let witness_size = hasher.witness_size(preimg.len());
                 let witness = local.next_n_aux(index, witness_size);
-                let img_vars = hasher.eval_preimg(builder, preimg, witness, sel.clone());
-                for img_var in img_vars {
+                hasher.eval_preimg(builder, preimg, img_vars, witness, sel.clone());
+                for &img_var in img_vars {
                     map.push(Val::Expr(img_var.into()))
                 }
             }

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -259,9 +259,11 @@ impl<F> Op<F> {
             }
             Op::Hash(preimg) => {
                 let hasher = &toplevel.hasher;
+                let img_size = hasher.img_size();
                 let witness_size = hasher.witness_size(preimg.len());
-                *aux += witness_size;
-                degrees.extend(vec![1; witness_size]);
+                let aux_size = img_size + witness_size;
+                *aux += aux_size;
+                degrees.extend(vec![1; aux_size]);
             }
             Op::Debug(..) => (),
         }

--- a/src/lair/hasher.rs
+++ b/src/lair/hasher.rs
@@ -23,9 +23,10 @@ pub trait Hasher<F>: Default + Sync {
         &self,
         builder: &mut AB,
         preimg: Vec<AB::Expr>,
+        img: &[AB::Var],
         witness: &[AB::Var],
         is_real: AB::Expr,
-    ) -> Vec<AB::Var>;
+    );
 }
 
 pub struct LurkHasher {
@@ -92,12 +93,14 @@ impl Hasher<BabyBear> for LurkHasher {
     }
 
     fn populate_witness(&self, preimg: &[BabyBear], witness: &mut [BabyBear]) -> Vec<BabyBear> {
-        match preimg.len() {
+        let mut out: Vec<_> = match preimg.len() {
             24 => populate_witness::<BabyBearConfig24, 24>(sized!(preimg), witness).into(),
             32 => populate_witness::<BabyBearConfig32, 32>(sized!(preimg), witness).into(),
             48 => populate_witness::<BabyBearConfig48, 48>(sized!(preimg), witness).into(),
             _ => unimplemented!(),
-        }
+        };
+        out.truncate(8);
+        out
     }
 
     fn witness_size(&self, preimg_size: usize) -> usize {
@@ -113,16 +116,32 @@ impl Hasher<BabyBear> for LurkHasher {
         &self,
         builder: &mut AB,
         preimg: Vec<AB::Expr>,
+        img: &[AB::Var],
         witness: &[AB::Var],
         is_real: AB::Expr,
-    ) -> Vec<AB::Var> {
+    ) {
         match preimg.len() {
-            24 => eval_input::<AB, BabyBearConfig24, 24>(builder, sized!(preimg), witness, is_real)
-                .into(),
-            32 => eval_input::<AB, BabyBearConfig32, 32>(builder, sized!(preimg), witness, is_real)
-                .into(),
-            48 => eval_input::<AB, BabyBearConfig48, 48>(builder, sized!(preimg), witness, is_real)
-                .into(),
+            24 => eval_input::<AB, BabyBearConfig24, 24>(
+                builder,
+                sized!(preimg),
+                img,
+                witness,
+                is_real,
+            ),
+            32 => eval_input::<AB, BabyBearConfig32, 32>(
+                builder,
+                sized!(preimg),
+                img,
+                witness,
+                is_real,
+            ),
+            48 => eval_input::<AB, BabyBearConfig48, 48>(
+                builder,
+                sized!(preimg),
+                img,
+                witness,
+                is_real,
+            ),
             _ => unimplemented!(),
         }
     }

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -303,6 +303,7 @@ impl<F: PrimeField> Op<F> {
                 let img = hasher.populate_witness(&preimg, &mut witness);
                 for f in img {
                     map.push((f, 1));
+                    slice.push_aux(index, f);
                 }
                 for f in witness {
                     slice.push_aux(index, f);

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1215,8 +1215,8 @@ mod test {
         expect_eq(ingress_builtin.width(), expect!["44"]);
         expect_eq(egress.width(), expect!["60"]);
         expect_eq(egress_builtin.width(), expect!["37"]);
-        expect_eq(hash_32_8.width(), expect!["669"]);
-        expect_eq(hash_48_8.width(), expect!["1005"]);
+        expect_eq(hash_32_8.width(), expect!["645"]);
+        expect_eq(hash_48_8.width(), expect!["965"]);
 
         let all_chips = [
             &lurk_main,

--- a/src/poseidon/wide/columns.rs
+++ b/src/poseidon/wide/columns.rs
@@ -3,14 +3,6 @@ use std::mem::size_of;
 
 use hybrid_array::{typenum::*, Array, ArraySize};
 
-pub struct Poseidon2Cols<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize>
-where
-    Sub1<C::R_P>: ArraySize,
-{
-    pub(super) perm: Poseidon2PermutationCols<T, C, WIDTH>,
-    pub output: [T; WIDTH],
-}
-
 /// Columns for the "narrow" Poseidon2 chip.
 ///
 /// As an optimization, we can represent all of the internal rounds without columns for intermediate
@@ -20,7 +12,7 @@ where
 /// 2) the rest of the state elements at the beginning of the internal rounds
 #[derive(Clone, Debug)]
 #[repr(C)]
-pub struct Poseidon2PermutationCols<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize>
+pub struct Poseidon2Cols<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize>
 where
     Sub1<C::R_P>: ArraySize,
 {

--- a/src/poseidon/wide/mod.rs
+++ b/src/poseidon/wide/mod.rs
@@ -29,7 +29,8 @@ mod test {
     {
         is_real: T,
         input: [T; WIDTH],
-        poseidon: Poseidon2Cols<T, C, WIDTH>,
+        output: [T; WIDTH],
+        perm: Poseidon2Cols<T, C, WIDTH>,
     }
 
     impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> BaseAir<C::F> for Chip<C, WIDTH>
@@ -51,9 +52,12 @@ mod test {
             let row = main.row_slice(0);
             let local = Cols::<AB::Var, C, WIDTH>::from_slice(&row);
 
-            local
-                .poseidon
-                .eval(builder, local.input.map(Into::into), local.is_real.into());
+            local.perm.eval(
+                builder,
+                local.input.map(Into::into),
+                &local.output,
+                local.is_real.into(),
+            );
         }
     }
 
@@ -95,7 +99,8 @@ mod test {
                     let cols = Cols::<C::F, C, WIDTH>::from_slice_mut(row);
                     cols.is_real = C::F::one();
                     cols.input = input;
-                    cols.poseidon.populate(input)
+                    cols.output = cols.perm.populate(input);
+                    cols.output
                 })
                 .collect();
 

--- a/src/poseidon/wide/trace.rs
+++ b/src/poseidon/wide/trace.rs
@@ -2,7 +2,7 @@ use std::iter::zip;
 
 use crate::poseidon::config::PoseidonConfig;
 
-use crate::poseidon::wide::columns::{Poseidon2Cols, Poseidon2PermutationCols};
+use crate::poseidon::wide::columns::Poseidon2Cols;
 use hybrid_array::{typenum::Sub1, ArraySize};
 use p3_field::AbstractField;
 use p3_symmetric::Permutation;
@@ -19,16 +19,6 @@ where
 }
 
 impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> Poseidon2Cols<C::F, C, WIDTH>
-where
-    Sub1<C::R_P>: ArraySize,
-{
-    pub(crate) fn populate(&mut self, input: [C::F; WIDTH]) -> [C::F; WIDTH] {
-        self.output = self.perm.populate(input);
-        self.output
-    }
-}
-
-impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> Poseidon2PermutationCols<C::F, C, WIDTH>
 where
     Sub1<C::R_P>: ArraySize,
 {


### PR DESCRIPTION
Following #109, this PR modifies the Hash implementation to use auxiliary variables to store the output of a hash. This allows us to replace `Poseidon2Cols` with `Poseidon2PermutationCols` (renaming) and save 8 columns. 

Moreover, the implementation of Poseidon was returning an output of length `WIDTH` rather than a digest of size 8. 