### PR TITLE
fix: cleanup `QueryRecord` for consecutive executions

### DIFF
--- a/src/lair/bytecode.rs
+++ b/src/lair/bytecode.rs
@@ -25,8 +25,9 @@ pub enum Op<F> {
     /// at index `i` in the toplevel when applied to the arguments at positions
     /// `[a, b, ...]` in the stack
     Call(usize, List<usize>),
-    /// `PreImg(i, [a, b, ...])` extends the stack with the preimage of the function
-    /// of index `i` on the arguments at positions `[a, b, ...]` in the stack
+    /// `PreImg(i, [a, b, ...])` extends the stack with the latest preimage
+    /// (beware of non-injectivity) of the function of index `i` when called with
+    /// arguments at positions `[a, b, ...]` in the stack
     PreImg(usize, List<usize>),
     /// `Store([y, ...])` pushes to the stack the pointer to `[y, ...]`
     Store(List<usize>),

--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -67,8 +67,8 @@ pub enum OpE<F> {
     /// `Call([x, ...], foo, [y, ...])` binds `x, ...` to the output of `foo`
     /// when applied to the arguments `y, ...`
     Call(VarList, Name, VarList),
-    /// `PreImg([x, ...], foo, [y, ...])` binds `x, ...` to the preimage of `foo`
-    /// when on the arguments `y, ...`
+    /// `PreImg([x, ...], foo, [y, ...])` binds `x, ...` to the latest preimage
+    /// (beware of non-injectivity) of `foo` when called with arguments `y, ...`
     PreImg(VarList, Name, VarList),
     /// `Store(x, [y, ...])` binds `x` to a pointer to `[y, ...]`
     Store(Var, VarList),

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1359,7 +1359,11 @@ mod test {
             egress_chip.execute_iter(egress_args.clone(), queries);
             let egress_out = queries.get_output(egress_chip.func, &egress_args);
 
-            assert_eq!(*egress_out, *digest, "ingress -> egress doesn't roundtrip");
+            assert_eq!(
+                egress_out,
+                digest.as_ref(),
+                "ingress -> egress doesn't roundtrip"
+            );
 
             let hash_32_8_trace = hash_32_8_chip.generate_trace_parallel(queries);
             debug_constraints_collecting_queries(&hash_32_8_chip, &[], &hash_32_8_trace);


### PR DESCRIPTION
The old `reset_multiplicities` wouldn't be enough to accomplish consecutive executions because existing records could short-circuit computations, messing up multiplicities.

The changes suggested here accomplish the following:
* Actually clean up records on `QueryRecord::clean` because memoized records won't help here. But keep the records of invertible funcs because we need to remember those preimages in order to implement `open`;
* Signal a recomputation even if a queried record is found when its multiplicity is zero;
* Add a test showing that cleaning up records is consistent even in the presence of an invertible function;