### PR TITLE
chore: Remove `unsafe` usage in `poseidon` by using `AlignedBorrow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ p3-symmetric = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1"
 p3-uni-stark = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1" }
 p3-util = { git = "https://github.com/lurk-lab/Plonky3.git", branch = "sp1" }
 sphinx-core = { git = "ssh://git@github.com/lurk-lab/sphinx.git", branch = "dev"}
+sphinx-derive = { git = "ssh://git@github.com/lurk-lab/sphinx.git", branch = "dev" }
 anyhow = "1.0.72"
 arc-swap = "1.7.1"
 base-x = "0.2.11"
@@ -78,6 +79,7 @@ p3-poseidon2 = { workspace = true }
 p3-symmetric = { workspace = true }
 p3-util = { workspace = true }
 sphinx-core = { workspace = true }
+sphinx-derive = { workspace = true }
 hashbrown = { workspace = true }
 
 [dev-dependencies]

--- a/src/poseidon/air.rs
+++ b/src/poseidon/air.rs
@@ -2,6 +2,7 @@
 
 use core::mem::size_of;
 use std::array;
+use std::borrow::Borrow;
 use std::iter::zip;
 
 use itertools::izip;
@@ -24,9 +25,9 @@ impl<AB: AirBuilder, C: PoseidonConfig<WIDTH, F = AB::F>, const WIDTH: usize> Ai
     fn eval(&self, builder: &mut AB) {
         let main = builder.main();
         let local = main.row_slice(0);
-        let local = Poseidon2Cols::<AB::Var, C, WIDTH>::from_slice(&local);
+        let local: &Poseidon2Cols<AB::Var, C, WIDTH> = (*local).borrow();
         let next = main.row_slice(1);
-        let next = Poseidon2Cols::<AB::Var, C, WIDTH>::from_slice(&next);
+        let next: &Poseidon2Cols<AB::Var, C, WIDTH> = (*next).borrow();
 
         let R_F = C::r_f();
         let R_P = C::r_p();

--- a/src/poseidon/columns.rs
+++ b/src/poseidon/columns.rs
@@ -2,16 +2,16 @@
 
 use core::array;
 use std::iter::zip;
-use std::mem::size_of;
 
 use super::config::PoseidonConfig;
 
 use hybrid_array::Array;
 use p3_field::AbstractField;
 use p3_symmetric::Permutation;
+use sphinx_derive::AlignedBorrow;
 
 /// The column layout for the chip.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, AlignedBorrow)]
 #[repr(C)]
 pub struct Poseidon2Cols<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize> {
     pub(crate) input: [T; WIDTH],
@@ -21,16 +21,6 @@ pub struct Poseidon2Cols<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize> {
     pub(crate) sbox_deg_3: [T; WIDTH],
     pub(crate) sbox_deg_7: [T; WIDTH],
     pub(crate) output: [T; WIDTH],
-}
-
-impl<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize> Poseidon2Cols<T, C, WIDTH> {
-    #[inline]
-    pub fn from_slice(slice: &[T]) -> &Self {
-        let num_cols = size_of::<Poseidon2Cols<u8, C, WIDTH>>();
-        assert_eq!(slice.len(), num_cols);
-        let (_, shorts, _) = unsafe { slice.align_to::<Poseidon2Cols<T, C, WIDTH>>() };
-        &shorts[0]
-    }
 }
 
 impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> Poseidon2Cols<C::F, C, WIDTH> {

--- a/src/poseidon/wide/air.rs
+++ b/src/poseidon/wide/air.rs
@@ -1,12 +1,13 @@
 use crate::poseidon::config::PoseidonConfig;
-use std::iter::zip;
+use crate::poseidon::wide::columns::Poseidon2Cols;
 
 use hybrid_array::{typenum::*, ArraySize};
-
-use crate::poseidon::wide::columns::Poseidon2Cols;
 use p3_air::AirBuilder;
 use p3_field::AbstractField;
 use p3_symmetric::Permutation;
+
+use std::borrow::Borrow;
+use std::iter::zip;
 
 /// Given a witness of size `Poseidon2Cols::num_cols` and an expected output digest,
 /// apply the Poseidon2 permutation over the input and compare the returned state,
@@ -21,7 +22,7 @@ pub fn eval_input<AB: AirBuilder, C: PoseidonConfig<WIDTH, F = AB::F>, const WID
 ) where
     Sub1<C::R_P>: ArraySize,
 {
-    let cols = Poseidon2Cols::<AB::Var, C, WIDTH>::from_slice(witness);
+    let cols: &Poseidon2Cols<AB::Var, C, WIDTH> = witness.borrow();
     cols.eval(builder, input, output, is_real);
 }
 

--- a/src/poseidon/wide/columns.rs
+++ b/src/poseidon/wide/columns.rs
@@ -2,6 +2,7 @@ use crate::poseidon::config::PoseidonConfig;
 use std::mem::size_of;
 
 use hybrid_array::{typenum::*, Array, ArraySize};
+use sphinx_derive::AlignedBorrow;
 
 /// Columns for the "narrow" Poseidon2 chip.
 ///
@@ -10,7 +11,7 @@ use hybrid_array::{typenum::*, Array, ArraySize};
 /// degree 1, so all state elements at the end can be expressed as a degree-3 polynomial of:
 /// 1) the 0th state element at rounds prior to the current round
 /// 2) the rest of the state elements at the beginning of the internal rounds
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, AlignedBorrow)]
 #[repr(C)]
 pub struct Poseidon2Cols<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize>
 where
@@ -35,23 +36,5 @@ where
 {
     pub const fn num_cols() -> usize {
         size_of::<Poseidon2Cols<u8, C, WIDTH>>()
-    }
-
-    #[inline]
-    pub fn from_slice(slice: &[T]) -> &Self {
-        let num_cols = Poseidon2Cols::<T, C, WIDTH>::num_cols();
-
-        debug_assert_eq!(slice.len(), num_cols);
-        let (_, shorts, _) = unsafe { slice.align_to::<Poseidon2Cols<T, C, WIDTH>>() };
-        &shorts[0]
-    }
-
-    #[inline]
-    pub fn from_slice_mut(slice: &mut [T]) -> &mut Self {
-        let num_cols = Poseidon2Cols::<T, C, WIDTH>::num_cols();
-
-        debug_assert_eq!(slice.len(), num_cols);
-        let (_, shorts, _) = unsafe { slice.align_to_mut::<Poseidon2Cols<T, C, WIDTH>>() };
-        &mut shorts[0]
     }
 }

--- a/src/poseidon/wide/trace.rs
+++ b/src/poseidon/wide/trace.rs
@@ -1,11 +1,10 @@
-use std::iter::zip;
-
 use crate::poseidon::config::PoseidonConfig;
-
 use crate::poseidon::wide::columns::Poseidon2Cols;
 use hybrid_array::{typenum::Sub1, ArraySize};
 use p3_field::AbstractField;
 use p3_symmetric::Permutation;
+use std::borrow::BorrowMut;
+use std::iter::zip;
 
 pub fn populate_witness<C: PoseidonConfig<WIDTH>, const WIDTH: usize>(
     input: [C::F; WIDTH],
@@ -14,7 +13,7 @@ pub fn populate_witness<C: PoseidonConfig<WIDTH>, const WIDTH: usize>(
 where
     Sub1<C::R_P>: ArraySize,
 {
-    let cols = Poseidon2Cols::<C::F, C, WIDTH>::from_slice_mut(witness);
+    let cols: &mut Poseidon2Cols<C::F, C, WIDTH> = witness.borrow_mut();
     cols.populate(input)
 }
 


### PR DESCRIPTION
- Replace the `from_slice` methods with calls to `borrow`
- Derive `AlignedBorrow` for different Columns types
- Parallelize skinny Poseidon trace generation