### PR TITLE
chore: erase all queries on cleanup

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -51,7 +51,7 @@ fn setup<H: Hasher<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut queries = QueryRecord::new(toplevel);
-    queries.inject_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+    queries.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1398,7 +1398,7 @@ mod test {
             } = zstore.read_with_state(state.clone(), expr).unwrap();
 
             let queries = &mut QueryRecord::new(toplevel);
-            queries.inject_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+            queries.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
 
             let ZPtr {
                 tag: expected_tag,
@@ -1497,7 +1497,7 @@ mod test {
             let digest: List<_> = digest.into();
 
             let queries = &mut QueryRecord::new(toplevel);
-            queries.inject_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+            queries.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
 
             let mut ingress_args = [F::zero(); 16];
             ingress_args[0] = tag;


### PR DESCRIPTION
This is both a simplification and an optimization, which allows us to do better memory cleanup in between consecutive executions without losing img->preimg maps for invertible queries.

Also, query injection can be restricted to invertible functions because queries memoized by injection are useless.