### PR TITLE
chore: define a single function for Lair execution

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -72,7 +72,7 @@ fn evaluation(c: &mut Criterion) {
         b.iter_batched(
             || (args.clone(), queries.clone()),
             |(args, mut queries)| {
-                toplevel.execute_iter(lurk_main.func(), &args, &mut queries);
+                toplevel.execute(lurk_main.func(), &args, &mut queries);
             },
             BatchSize::SmallInput,
         )
@@ -85,7 +85,7 @@ fn trace_generation(c: &mut Criterion) {
         let toplevel = build_lurk_toplevel();
         let (args, lurk_main, mut queries) = setup(arg, &toplevel);
 
-        toplevel.execute_iter(lurk_main.func(), &args, &mut queries);
+        toplevel.execute(lurk_main.func(), &args, &mut queries);
 
         let func_chips = FuncChip::from_toplevel(&toplevel);
 

--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -268,7 +268,7 @@ impl<F: Field> Op<F> {
                 map.push(x);
             }
             Op::Call(idx, inp, _) => {
-                let func = toplevel.get_by_index(*idx).unwrap();
+                let func = toplevel.get_by_index(*idx);
                 let mut out = Vec::with_capacity(func.output_size);
                 for _ in 0..func.output_size {
                     let o = *local.next_aux(index);
@@ -292,7 +292,7 @@ impl<F: Field> Op<F> {
                 );
             }
             Op::PreImg(idx, out, _) => {
-                let func = toplevel.get_by_index(*idx).unwrap();
+                let func = toplevel.get_by_index(*idx);
                 let mut inp = Vec::with_capacity(func.input_size);
                 for _ in 0..func.input_size {
                     let i = *local.next_aux(index);
@@ -587,7 +587,7 @@ mod tests {
         let fib_chip = FuncChip::from_name("fib", &toplevel);
         let args = &[field_from_u32(20000)];
         let queries = &mut QueryRecord::new(&toplevel);
-        toplevel.execute_iter_by_name("fib", args, queries);
+        toplevel.execute_by_name("fib", args, queries);
         let fib_trace = fib_chip.generate_trace_parallel(queries);
 
         let _ = debug_constraints_collecting_queries(&fib_chip, &[], None, &fib_trace);
@@ -611,13 +611,13 @@ mod tests {
 
         let queries = &mut QueryRecord::new(&toplevel);
         let args = &[field_from_u32(4)];
-        toplevel.execute_iter_by_name("not", args, queries);
+        toplevel.execute_by_name("not", args, queries);
         let args = &[field_from_u32(8)];
-        toplevel.execute_iter_by_name("not", args, queries);
+        toplevel.execute_by_name("not", args, queries);
         let args = &[field_from_u32(0)];
-        toplevel.execute_iter_by_name("not", args, queries);
+        toplevel.execute_by_name("not", args, queries);
         let args = &[field_from_u32(1)];
-        toplevel.execute_iter_by_name("not", args, queries);
+        toplevel.execute_by_name("not", args, queries);
         let not_trace = not_chip.generate_trace_sequential(queries);
 
         let not_width = not_chip.width();
@@ -636,13 +636,13 @@ mod tests {
         assert_eq!(not_trace, expected_not_trace);
 
         let args = &[field_from_u32(4), field_from_u32(2)];
-        toplevel.execute_iter_by_name("eq", args, queries);
+        toplevel.execute_by_name("eq", args, queries);
         let args = &[field_from_u32(4), field_from_u32(4)];
-        toplevel.execute_iter_by_name("eq", args, queries);
+        toplevel.execute_by_name("eq", args, queries);
         let args = &[field_from_u32(0), field_from_u32(3)];
-        toplevel.execute_iter_by_name("eq", args, queries);
+        toplevel.execute_by_name("eq", args, queries);
         let args = &[field_from_u32(0), field_from_u32(0)];
-        toplevel.execute_iter_by_name("eq", args, queries);
+        toplevel.execute_by_name("eq", args, queries);
         let eq_trace = eq_chip.generate_trace_sequential(queries);
 
         let eq_width = eq_chip.width();
@@ -681,13 +681,13 @@ mod tests {
         let queries = &mut QueryRecord::new(&toplevel);
         let f = field_from_u32;
         let args = &[f(0), f(0), f(0), f(0)];
-        toplevel.execute_iter_by_name("if_many", args, queries);
+        toplevel.execute_by_name("if_many", args, queries);
         let args = &[f(1), f(3), f(8), f(2)];
-        toplevel.execute_iter_by_name("if_many", args, queries);
+        toplevel.execute_by_name("if_many", args, queries);
         let args = &[f(0), f(0), f(4), f(1)];
-        toplevel.execute_iter_by_name("if_many", args, queries);
+        toplevel.execute_by_name("if_many", args, queries);
         let args = &[f(0), f(0), f(0), f(9)];
-        toplevel.execute_iter_by_name("if_many", args, queries);
+        toplevel.execute_by_name("if_many", args, queries);
 
         let if_many_trace = if_many_chip.generate_trace_parallel(queries);
 
@@ -741,15 +741,15 @@ mod tests {
         let queries = &mut QueryRecord::new(&toplevel);
         let f = field_from_u32;
         let args = &[f(0), f(0)];
-        toplevel.execute_iter_by_name("match_many", args, queries);
+        toplevel.execute_by_name("match_many", args, queries);
         let args = &[f(0), f(1)];
-        toplevel.execute_iter_by_name("match_many", args, queries);
+        toplevel.execute_by_name("match_many", args, queries);
         let args = &[f(1), f(0)];
-        toplevel.execute_iter_by_name("match_many", args, queries);
+        toplevel.execute_by_name("match_many", args, queries);
         let args = &[f(1), f(1)];
-        toplevel.execute_iter_by_name("match_many", args, queries);
+        toplevel.execute_by_name("match_many", args, queries);
         let args = &[f(0), f(8)];
-        toplevel.execute_iter_by_name("match_many", args, queries);
+        toplevel.execute_by_name("match_many", args, queries);
 
         let match_many_trace = match_many_chip.generate_trace_parallel(queries);
 

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -37,13 +37,13 @@ pub struct FuncChip<'a, F, H: Hasher<F>> {
 impl<'a, F, H: Hasher<F>> FuncChip<'a, F, H> {
     #[inline]
     pub fn from_name(name: &'static str, toplevel: &'a Toplevel<F, H>) -> Self {
-        let func = toplevel.get_by_name(name).expect("Func not found");
+        let func = toplevel.get_by_name(name);
         Self::from_func(func, toplevel)
     }
 
     #[inline]
     pub fn from_index(idx: usize, toplevel: &'a Toplevel<F, H>) -> Self {
-        let func = toplevel.get_by_index(idx).expect("Index out of bounds");
+        let func = toplevel.get_by_index(idx);
         Self::from_func(func, toplevel)
     }
 
@@ -248,14 +248,14 @@ impl<F> Op<F> {
                 }
             }
             Op::Call(f_idx, ..) => {
-                let func = toplevel.get_by_index(*f_idx).unwrap();
+                let func = toplevel.get_by_index(*f_idx);
                 let out_size = func.output_size;
                 // output of function, prev_nonce, prev_count, count_inv
                 *aux += out_size + 3;
                 degrees.extend(vec![1; out_size]);
             }
             Op::PreImg(f_idx, ..) => {
-                let func = toplevel.get_by_index(*f_idx).unwrap();
+                let func = toplevel.get_by_index(*f_idx);
                 let inp_size = func.input_size;
                 // input of function, prev_nonce, prev_count, count_inv
                 *aux += inp_size + 3;

--- a/src/lair/toplevel.rs
+++ b/src/lair/toplevel.rs
@@ -41,13 +41,16 @@ impl<F: Clone + Ord, H: Hasher<F>> Toplevel<F, H> {
 
 impl<F, H: Hasher<F>> Toplevel<F, H> {
     #[inline]
-    pub fn get_by_index(&self, i: usize) -> Option<&Func<F>> {
-        self.map.get_index(i).map(|(_, func)| func)
+    pub fn get_by_index(&self, i: usize) -> &Func<F> {
+        self.map
+            .get_index(i)
+            .map(|(_, func)| func)
+            .expect("Index out of bounds")
     }
 
     #[inline]
-    pub fn get_by_name(&self, name: &'static str) -> Option<&Func<F>> {
-        self.map.get(&Name(name))
+    pub fn get_by_name(&self, name: &'static str) -> &Func<F> {
+        self.map.get(&Name(name)).expect("Func not found")
     }
 
     #[inline]

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -426,7 +426,7 @@ mod tests {
     fn lair_layout_sizes_test() {
         let toplevel = demo_toplevel::<_, LurkHasher>();
 
-        let factorial = toplevel.get_by_name("factorial").unwrap();
+        let factorial = toplevel.get_by_name("factorial");
         let out = factorial.compute_layout_sizes(&toplevel);
         let expected_layout_sizes = LayoutSizes {
             nonce: 1,
@@ -592,7 +592,7 @@ mod tests {
         let two = &[F::from_canonical_u32(1), F::from_canonical_u32(0)];
         let three = &[F::from_canonical_u32(1), F::from_canonical_u32(1)];
         let queries = &mut QueryRecord::new(&toplevel);
-        let test_func = toplevel.get_by_name("test").unwrap();
+        let test_func = toplevel.get_by_name("test");
         toplevel.execute(test_func, zero, queries);
         toplevel.execute(test_func, one, queries);
         toplevel.execute(test_func, two, queries);

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1403,7 +1403,7 @@ mod test {
             full_input[8..16].copy_from_slice(&expr_digest);
 
             let full_input: List<_> = full_input.into();
-            toplevel.execute_iter(lurk_main.func, &full_input, record);
+            toplevel.execute(lurk_main.func, &full_input, record);
             let result = record.get_output(lurk_main.func, &full_input);
 
             assert_eq!(&result[0], &expected_tag.to_field());
@@ -1492,8 +1492,8 @@ mod test {
     fn test_ingress_egress() {
         let toplevel = &build_lurk_toplevel();
 
-        let ingress = toplevel.get_by_name("ingress").unwrap();
-        let egress = toplevel.get_by_name("egress").unwrap();
+        let ingress = toplevel.get_by_name("ingress");
+        let egress = toplevel.get_by_name("egress");
         let hash_32_8_chip = FuncChip::from_name("hash_32_8", toplevel);
 
         let state = State::init_lurk_state().rccell();
@@ -1512,11 +1512,11 @@ mod test {
             ingress_args[0] = tag;
             ingress_args[8..].copy_from_slice(&digest);
 
-            toplevel.execute_iter(ingress, &ingress_args, queries);
+            toplevel.execute(ingress, &ingress_args, queries);
             let ingress_out_ptr = queries.get_output(ingress, &ingress_args)[0];
 
             let egress_args = &[tag, ingress_out_ptr];
-            toplevel.execute_iter(egress, egress_args, queries);
+            toplevel.execute(egress, egress_args, queries);
             let egress_out = queries.get_output(egress, egress_args);
 
             assert_eq!(


### PR DESCRIPTION
* Our recursive algorithm for Lair execution was easy to manipulate and prototype but it often caused stack overflows due to large recursion depths
* Our iterative algorithm for Lair execution didn't have the stack overflow problem but it was too complicated to maintain

These changes replace both by an iterative algorithm that's easy to maintain.