### PR TITLE
fix: adhere to Sphinx's design for public values

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -89,8 +89,8 @@ fn trace_generation(c: &mut Criterion) {
     c.bench_function(&format!("trace-generation-{arg}"), |b| {
         let toplevel = build_lurk_toplevel();
         let (args, lurk_main, mut record) = setup(arg, &toplevel);
-        let out = toplevel.execute(lurk_main.func(), &args, &mut record);
-        let lair_chips = build_lair_chip_vector(&lurk_main, args.into(), out.into());
+        toplevel.execute(lurk_main.func(), &args, &mut record);
+        let lair_chips = build_lair_chip_vector(&lurk_main);
         b.iter(|| {
             lair_chips.par_iter().for_each(|func_chip| {
                 let shard = Shard::new(&record);
@@ -109,12 +109,12 @@ fn e2e(c: &mut Criterion) {
         b.iter_batched(
             || (record.clone(), args.clone()),
             |(mut record, args)| {
-                let out = toplevel.execute(lurk_main.func(), &args, &mut record);
+                toplevel.execute(lurk_main.func(), &args, &mut record);
                 let config = BabyBearPoseidon2::new();
                 let machine = StarkMachine::new(
                     config,
-                    build_chip_vector(&lurk_main, args.into(), out.into()),
-                    0,
+                    build_chip_vector(&lurk_main),
+                    record.expect_public_values().len(),
                 );
                 let (pk, _) = machine.setup(&LairMachineProgram);
                 let mut challenger_p = machine.config().challenger();

--- a/src/lair/lair_chip.rs
+++ b/src/lair/lair_chip.rs
@@ -1,5 +1,5 @@
-use p3_air::{Air, AirBuilder, BaseAir};
-use p3_field::{AbstractField, Field, PrimeField32};
+use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
+use p3_field::{AbstractField, PrimeField32};
 use p3_matrix::{dense::RowMajorMatrix, Matrix};
 use sphinx_core::{
     air::{EventLens, MachineAir, MachineProgram, WithEvents},
@@ -9,36 +9,39 @@ use sphinx_core::{
 use crate::air::builder::{LookupBuilder, RequireRecord};
 
 use super::{
+    bytecode::Func,
     execute::{Shard, MEM_TABLE_SIZES},
     func_chip::FuncChip,
     hasher::Hasher,
     memory::MemChip,
-    relations::CallRelation,
+    relations::OuterCallRelation,
 };
 
 pub enum LairChip<'a, F, H: Hasher<F>> {
     Func(FuncChip<'a, F, H>),
     Mem(MemChip<F>),
     Entrypoint {
-        func_idx: F,
-        inp: Vec<F>, // TODO: remove this!
-        out: Vec<F>, // TODO: remove this!
+        func_idx: usize,
+        num_public_values: usize,
     },
     Preprocessed,
 }
 
 impl<'a, F, H: Hasher<F>> LairChip<'a, F, H> {
     #[inline]
-    pub fn entrypoint(func_idx: F, inp: Vec<F>, out: Vec<F>) -> Self {
-        Self::Entrypoint { func_idx, inp, out }
+    pub fn entrypoint(func: &Func<F>) -> Self {
+        Self::Entrypoint {
+            func_idx: func.index,
+            num_public_values: func.input_size + func.output_size,
+        }
     }
 }
 
-impl<'a, F: Field, H: Hasher<F>> WithEvents<'a> for LairChip<'_, F, H> {
+impl<'a, F: PrimeField32, H: Hasher<F>> WithEvents<'a> for LairChip<'_, F, H> {
     type Events = &'a Shard<'a, F>;
 }
 
-impl<'a, F: Field, H: Hasher<F>> EventLens<LairChip<'a, F, H>> for Shard<'a, F> {
+impl<'a, F: PrimeField32, H: Hasher<F>> EventLens<LairChip<'a, F, H>> for Shard<'a, F> {
     fn events(&self) -> <LairChip<'a, F, H> as WithEvents<'_>>::Events {
         self
     }
@@ -49,7 +52,10 @@ impl<'a, F: Sync, H: Hasher<F>> BaseAir<F> for LairChip<'a, F, H> {
         match self {
             Self::Func(func_chip) => func_chip.width(),
             Self::Mem(mem_chip) => mem_chip.width(),
-            Self::Entrypoint { .. } | Self::Preprocessed => 1,
+            Self::Entrypoint {
+                num_public_values, ..
+            } => *num_public_values,
+            Self::Preprocessed => 1,
         }
     }
 }
@@ -69,10 +75,8 @@ impl<'a, F: PrimeField32, H: Hasher<F>> MachineAir<F> for LairChip<'a, F, H> {
     fn name(&self) -> String {
         match self {
             Self::Func(func_chip) => format!("Func[{}]", func_chip.func.name),
-            Self::Mem(mem_chip) => format!("{}-wide", mem_chip.len),
-            Self::Entrypoint { func_idx, .. } => {
-                format!("Entrypoint[{}]", func_idx)
-            }
+            Self::Mem(mem_chip) => format!("Mem[{}-wide]", mem_chip.len),
+            Self::Entrypoint { func_idx, .. } => format!("Entrypoint[{func_idx}]"),
             // the following is required by sphinx
             // TODO: engineer our way out of such upstream check
             Self::Preprocessed => "CPU".to_string(),
@@ -87,8 +91,12 @@ impl<'a, F: PrimeField32, H: Hasher<F>> MachineAir<F> for LairChip<'a, F, H> {
         match self {
             Self::Func(func_chip) => func_chip.generate_trace(shard.events()),
             Self::Mem(mem_chip) => mem_chip.generate_trace(shard.events()),
-            Self::Entrypoint { .. } => {
-                RowMajorMatrix::new(vec![F::from_bool(shard.index() == 0)], 1)
+            Self::Entrypoint {
+                num_public_values, ..
+            } => {
+                let public_values = shard.events().expect_public_values();
+                assert_eq!(*num_public_values, public_values.len());
+                RowMajorMatrix::new(public_values.to_vec(), *num_public_values)
             }
             Self::Preprocessed => RowMajorMatrix::new(vec![F::zero(); 1], 1),
         }
@@ -96,19 +104,19 @@ impl<'a, F: PrimeField32, H: Hasher<F>> MachineAir<F> for LairChip<'a, F, H> {
 
     fn generate_dependencies<EL: EventLens<Self>>(&self, _: &EL, _: &mut Self::Record) {}
 
-    fn included(&self, queries: &Self::Record) -> bool {
+    fn included(&self, shard: &Self::Record) -> bool {
         match self {
             Self::Func(func_chip) => {
-                let range = queries.get_func_range(func_chip.func.index);
+                let range = shard.get_func_range(func_chip.func.index);
                 !range.is_empty()
             }
             Self::Mem(_mem_chip) => {
-                queries.index == 0
+                shard.index == 0
                 // TODO: This snippet or equivalent is needed for memory sharding
-                // let range = queries.get_mem_range(mem_index_from_len(mem_chip.len));
+                // let range = shard.get_mem_range(mem_index_from_len(mem_chip.len));
                 // !range.is_empty()
             }
-            Self::Entrypoint { .. } => queries.index == 0,
+            Self::Entrypoint { .. } => shard.index == 0,
             Self::Preprocessed => true,
         }
     }
@@ -130,27 +138,37 @@ impl<'a, F: PrimeField32, H: Hasher<F>> MachineAir<F> for LairChip<'a, F, H> {
 
 impl<'a, AB, H: Hasher<AB::F>> Air<AB> for LairChip<'a, AB::F, H>
 where
-    AB: AirBuilder + LookupBuilder,
+    AB: AirBuilderWithPublicValues + LookupBuilder,
     <AB as AirBuilder>::Var: std::fmt::Debug,
 {
     fn eval(&self, builder: &mut AB) {
         match self {
             Self::Func(func_chip) => func_chip.eval(builder),
             Self::Mem(mem_chip) => mem_chip.eval(builder),
-            Self::Entrypoint { func_idx, inp, out } => {
-                let is_real = builder.main().get(0, 0).into();
+            Self::Entrypoint {
+                func_idx,
+                num_public_values,
+            } => {
+                let func_idx = AB::F::from_canonical_usize(*func_idx);
+                let public_values = builder.main().first_row().collect::<Vec<_>>();
+                assert_eq!(public_values.len(), *num_public_values);
 
-                builder.assert_bool(is_real.clone());
+                // these values aren't correct for all builders!
+                let public_values_from_builder = builder.public_values().to_vec();
+                for (&a, b) in public_values.iter().zip(public_values_from_builder) {
+                    // this is only accounted for by the builder used to collect constraints
+                    builder.assert_eq(a, b);
+                }
 
                 builder.require(
-                    CallRelation(*func_idx, inp.clone(), out.clone()),
+                    OuterCallRelation(func_idx, public_values),
                     AB::F::zero(),
                     RequireRecord {
                         prev_nonce: AB::F::zero(),
                         prev_count: AB::F::zero(),
                         count_inv: AB::F::one(),
                     },
-                    is_real,
+                    AB::F::one(),
                 );
             }
             Self::Preprocessed => {
@@ -164,19 +182,11 @@ where
 
 pub fn build_lair_chip_vector<'a, F: PrimeField32, H: Hasher<F>>(
     entry_func_chip: &FuncChip<'a, F, H>,
-    inp: Vec<F>,
-    out: Vec<F>,
 ) -> Vec<LairChip<'a, F, H>> {
     let toplevel = &entry_func_chip.toplevel;
     let func = &entry_func_chip.func;
-    assert_eq!(func.input_size, inp.len());
-    assert_eq!(func.output_size, out.len());
     let mut chip_vector = Vec::with_capacity(2 + toplevel.map.size() + MEM_TABLE_SIZES.len());
-    chip_vector.push(LairChip::entrypoint(
-        F::from_canonical_usize(func.index),
-        inp,
-        out,
-    ));
+    chip_vector.push(LairChip::entrypoint(func));
     chip_vector.push(LairChip::Preprocessed);
     for func_chip in FuncChip::from_toplevel(toplevel) {
         chip_vector.push(LairChip::Func(func_chip));
@@ -189,30 +199,11 @@ pub fn build_lair_chip_vector<'a, F: PrimeField32, H: Hasher<F>>(
 
 pub fn build_chip_vector<'a, F: PrimeField32, H: Hasher<F>>(
     entry_func_chip: &FuncChip<'a, F, H>,
-    inp: Vec<F>,
-    out: Vec<F>,
 ) -> Vec<Chip<F, LairChip<'a, F, H>>> {
-    build_lair_chip_vector(entry_func_chip, inp, out)
+    build_lair_chip_vector(entry_func_chip)
         .into_iter()
         .map(Chip::new)
         .collect()
-}
-
-pub fn set_chip_vector_io<F: PrimeField32, H: Hasher<F>>(
-    chip_vector: &mut [Chip<F, LairChip<'_, F, H>>],
-    new_inp: Vec<F>,
-    new_out: Vec<F>,
-) {
-    let LairChip::Entrypoint { func_idx, inp, out } = chip_vector[0].as_ref() else {
-        panic!("Invalid chip vector");
-    };
-    assert_eq!(inp.len(), new_inp.len());
-    assert_eq!(out.len(), new_out.len());
-    chip_vector[0] = Chip::new(LairChip::Entrypoint {
-        func_idx: *func_idx,
-        inp: new_inp,
-        out: new_out,
-    })
 }
 
 #[cfg(test)]
@@ -247,19 +238,21 @@ mod tests {
         });
         let toplevel = Toplevel::<F, H>::new(&[func_e]);
         let test_chip = FuncChip::from_name("test", &toplevel);
-        let mut queries = QueryRecord::new(&toplevel);
+        let mut record = QueryRecord::new(&toplevel);
 
-        let inp = &[];
-        toplevel.execute_by_name("test", inp, &mut queries);
-        let out = queries.get_output(test_chip.func, inp).to_vec();
+        toplevel.execute_by_name("test", &[], &mut record);
 
         let config = BabyBearPoseidon2::new();
-        let machine = StarkMachine::new(config, build_chip_vector(&test_chip, vec![], out), 0);
+        let machine = StarkMachine::new(
+            config,
+            build_chip_vector(&test_chip),
+            record.expect_public_values().len(),
+        );
 
         let (pk, vk) = machine.setup(&LairMachineProgram);
         let mut challenger_p = machine.config().challenger();
         let mut challenger_v = machine.config().challenger();
-        let shard = Shard::new(&queries);
+        let shard = Shard::new(&record);
 
         machine.debug_constraints(&pk, shard.clone());
         let opts = SphinxCoreOpts::default();

--- a/src/lair/memory.rs
+++ b/src/lair/memory.rs
@@ -28,9 +28,9 @@ impl<F: PrimeField32> MemChip<F> {
     }
 
     pub fn generate_trace(&self, shard: &Shard<'_, F>) -> RowMajorMatrix<F> {
-        let queries = &shard.queries().mem_queries;
+        let record = &shard.record().mem_queries;
         let mem_idx = mem_index_from_len(self.len);
-        let mem = &queries[mem_idx];
+        let mem = &record[mem_idx];
         let width = self.width();
 
         let height = mem.len().next_power_of_two().max(4); // TODO: Remove? loam#118

--- a/src/lair/relations.rs
+++ b/src/lair/relations.rs
@@ -7,6 +7,7 @@ const CALL_TAG: u32 = 0;
 const MEMORY_TAG: u32 = 1;
 
 pub struct CallRelation<Idx, Inp, Out>(pub Idx, pub Inp, pub Out);
+pub struct OuterCallRelation<Idx, PublicValues>(pub Idx, pub PublicValues);
 pub struct MemoryRelation<Ptr, ValuesIter>(pub Ptr, pub ValuesIter);
 
 impl<F: AbstractField, FuncIdx: Into<F>, IntoInputIter, IntoOutputIter, Value: Into<F>> Relation<F>
@@ -23,6 +24,20 @@ where
                 input.into_iter().map(Into::into),
                 output.into_iter().map(Into::into),
             ),
+        )
+    }
+}
+
+impl<F: AbstractField, FuncIdx: Into<F>, IntoValueIter, Value: Into<F>> Relation<F>
+    for OuterCallRelation<FuncIdx, IntoValueIter>
+where
+    IntoValueIter: IntoIterator<Item = Value>,
+{
+    fn values(self) -> impl IntoIterator<Item = F> {
+        let Self(func_idx, public_values) = self;
+        chain(
+            [F::from_canonical_u32(CALL_TAG), func_idx.into()],
+            public_values.into_iter().map(Into::into),
         )
     }
 }

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1403,14 +1403,12 @@ mod test {
             full_input[8..16].copy_from_slice(&expr_digest);
 
             let full_input: List<_> = full_input.into();
-            toplevel.execute(lurk_main.func, &full_input, &mut record);
-            let result = record.get_output(lurk_main.func, &full_input).to_vec();
+            let result = toplevel.execute(lurk_main.func, &full_input, &mut record);
 
             assert_eq!(&result[0], &expected_tag.to_field());
             assert_eq!(&result[8..], &expected_digest);
 
-            let lair_chips =
-                build_lair_chip_vector(&lurk_main, full_input.clone().into(), result.clone());
+            let lair_chips = build_lair_chip_vector(&lurk_main);
 
             let full_shard = Shard::new(&record);
             // Verify lookup queries without sharding
@@ -1446,8 +1444,8 @@ mod test {
 
             let machine = StarkMachine::new(
                 config.clone(),
-                build_chip_vector(&lurk_main, full_input.into(), result),
-                0,
+                build_chip_vector(&lurk_main),
+                record.expect_public_values().len(),
             );
             let (pk, _vk) = machine.setup(&LairMachineProgram);
             machine.debug_constraints(&pk, full_shard);


### PR DESCRIPTION
* Make `QueryRecord` hold public values, which are updated after execution
* Provide those values in `MachineRecord::public_values`
* Make `LairChip::Entrypoint` generate a trace with the public values as the only row
* Constrain it to equal the public values provided by the builder
* Use it to make the outermost require with a (new) `OuterCallRelation`