### PR TITLE
Optimize match with equal branches

### DIFF
--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -426,7 +426,7 @@ impl<F: Field> Ctrl<F> {
         <AB as AirBuilder>::Var: Debug,
     {
         match self {
-            Ctrl::Choose(_, cases) => {
+            Ctrl::Choose(_, cases, branches) => {
                 let map_len = map.len();
                 let init_state = index.save();
 
@@ -436,7 +436,7 @@ impl<F: Field> Ctrl<F> {
                     map.truncate(map_len);
                     index.restore(init_state);
                 };
-                cases.branches.iter().for_each(|(_, block)| process(block));
+                branches.iter().for_each(&mut process);
                 if let Some(block) = cases.default.as_ref() {
                     process(block)
                 };
@@ -749,6 +749,53 @@ mod tests {
                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .into_iter()
+            .map(F::from_canonical_u32)
+            .collect::<Vec<_>>(),
+            chip.width(),
+        );
+        assert_eq!(trace, expected_trace);
+        let _ = debug_constraints_collecting_queries(&chip, &[], None, &trace);
+    }
+
+    #[test]
+    fn lair_equal_branch_test() {
+        let func = func!(
+        fn test(a): [1] {
+            match a {
+                2, 3, 4 => {
+                    let one = 1;
+                    return one
+                }
+            };
+            return a
+        });
+        let toplevel = Toplevel::<F, Nochip>::new_pure(&[func]);
+        let mut queries = QueryRecord::new(&toplevel);
+        let f = field_from_u32;
+        let args = &[f(1)];
+        toplevel.execute_by_name("test", args, &mut queries);
+        let args = &[f(2)];
+        toplevel.execute_by_name("test", args, &mut queries);
+        let args = &[f(3)];
+        toplevel.execute_by_name("test", args, &mut queries);
+        let args = &[f(4)];
+        toplevel.execute_by_name("test", args, &mut queries);
+        let chip = FuncChip::from_name("test", &toplevel);
+        let trace = chip.generate_trace(&Shard::new(&queries));
+
+        #[rustfmt::skip]
+        let expected_trace = RowMajorMatrix::new(
+            [
+                // branch case:
+                //   nonce, input, (a-2)*(a-3), (a-2)*(a-3)*(a-4), dummy, last nonce, last count, two selectors
+                // default case:
+                //   nonce, input, 1/(a-2), 1/(a-3), 1/(a-4), last nonce, last count, two selectors
+                0, 1, 2013265920, 1006632960, 671088640, 0, 1, 0, 1,
+                1, 2,          0,          0,         0, 1, 0, 1, 0,
+                2, 3,          0,          0,         0, 1, 0, 1, 0,
+                3, 4,          2,          0,         0, 1, 0, 1, 0
             ]
             .into_iter()
             .map(F::from_canonical_u32)

--- a/src/lair/bytecode.rs
+++ b/src/lair/bytecode.rs
@@ -60,7 +60,8 @@ pub struct Block<F> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Ctrl<F> {
     /// `Choose(x, cases)` non-deterministically chooses which case to execute based on a value `x`
-    Choose(usize, Cases<F, F>),
+    /// The third item is the list of unique branches, needed for `eval`
+    Choose(usize, Cases<F, F>, List<Block<F>>), // TODO use Arc or indices so that blocks are not duplicated
     /// `ChooseMany(x, cases)` non-deterministically chooses which case to execute based on an array `x`
     ChooseMany(List<usize>, Cases<List<F>, F>),
     /// Contains the variables whose bindings will construct the output of the

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -555,7 +555,7 @@ impl<F: PrimeField32> Func<F> {
                         break;
                     }
                 }
-                ExecEntry::Ctrl(Ctrl::Choose(v, cases)) => {
+                ExecEntry::Ctrl(Ctrl::Choose(v, cases, _)) => {
                     let v = map[*v];
                     let block = cases.match_case(&v).expect("No match");
                     push_block_exec_entries!(block);

--- a/src/lair/expr.rs
+++ b/src/lair/expr.rs
@@ -101,8 +101,9 @@ pub struct BlockE<F> {
 /// Encodes the logical flow of a Lair program
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CtrlE<F> {
-    /// `Match(x, cases)` matches on `x` in order to decide which case to execute
-    Match(Var, CasesE<F, F>),
+    /// `Match(x, cases)` matches on `x` in order to decide which case to execute.
+    /// The list collects all the values that map to the same branch
+    Match(Var, CasesE<List<F>, F>),
     /// `MatchMany(x, cases)` matches on array `x` in order to decide which case to execute
     MatchMany(Var, CasesE<List<F>, F>),
     /// `If(b, t, f)` executes block `f` if `b` is zero and `t` otherwise

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -133,7 +133,7 @@ impl<F> Ctrl<F> {
                 // last nonce, last count
                 *aux += 2;
             }
-            Ctrl::Choose(_, cases) => {
+            Ctrl::Choose(_, cases, branches) => {
                 let degrees_len = degrees.len();
                 let mut max_aux = *aux;
                 let mut process = |block: &Block<_>| {
@@ -142,7 +142,7 @@ impl<F> Ctrl<F> {
                     degrees.truncate(degrees_len);
                     max_aux = max_aux.max(*block_aux);
                 };
-                cases.branches.iter().for_each(|(_, block)| process(block));
+                branches.iter().for_each(&mut process);
                 if let Some(block) = cases.default.as_ref() {
                     process(block)
                 };

--- a/src/lair/macros.rs
+++ b/src/lair/macros.rs
@@ -258,16 +258,11 @@ macro_rules! block {
         let mut branches = Vec::new();
         {
             $(
+                let f = $crate::lair::field_from_i32;
                 branches.push((
-                    $crate::lair::field_from_i32($num),
+                    [f($num), $(f($other_num), )*].into(),
                     $crate::block_init!( $branch )
                 ));
-                $(
-                    branches.push((
-                        $crate::lair::field_from_i32($other_num),
-                        $crate::block_init!( $branch ),
-                    ));
-                )*
             )*
         }
         let default = None $( .or (Some(Box::new($crate::block_init!({ $($def)* })))) )?;
@@ -306,15 +301,9 @@ macro_rules! block {
         {
             $(
                 branches.push((
-                    $raw.to_field(),
+                    [$raw.to_field(), $($other_raw.to_field(),)*].into(),
                     $crate::block_init!( $branch )
                 ));
-                $(
-                    branches.push((
-                        $other_raw.to_field(),
-                        $crate::block_init!( $branch ),
-                    ));
-                )*
             )*
         }
         let default = None $( .or (Some(Box::new($crate::block_init!({ $($def)* })))) )?;
@@ -329,15 +318,9 @@ macro_rules! block {
         {
             $(
                 branches.push((
-                    $cloj($raw),
+                    [$cloj($raw), $($cloj($other_raw),)*].into(),
                     $crate::block_init!( $branch )
                 ));
-                $(
-                    branches.push((
-                        $cloj($other_raw),
-                        $crate::block_init!( $branch ),
-                    ));
-                )*
             )*
         }
         let default = None $( .or (Some(Box::new($crate::block_init!({ $($def)* })))) )?;

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -162,10 +162,10 @@ impl<F: PrimeField32> Ctrl<F> {
                 slice.push_aux(index, provide.last_nonce);
                 slice.push_aux(index, provide.last_count);
             }
-            Ctrl::Choose(var, cases) => {
+            Ctrl::Choose(var, cases, _) => {
                 let val = map[*var].0;
                 let branch = cases.match_case(&val).expect("No match");
-                branch.populate_row(func_ctx, map, index, slice, shard, hasher);
+                branch.populate_row(ctx, map, index, slice);
             }
             Ctrl::ChooseMany(vars, cases) => {
                 let vals = vars.iter().map(|&var| map[var].0).collect();

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -382,7 +382,7 @@ fn egress_builtin<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> Func
     let branches = builtins
         .iter()
         .enumerate()
-        .map(|(i, (_, digest))| (F::from_canonical_usize(i), branch(digest.clone())))
+        .map(|(i, (_, digest))| ([F::from_canonical_usize(i)].into(), branch(digest.clone())))
         .collect();
     let cases = CasesE {
         branches,
@@ -1474,7 +1474,7 @@ mod test {
             expected.assert_eq(&computed.to_string());
         };
         expect_eq(lurk_main.width(), expect!["52"]);
-        expect_eq(eval.width(), expect!["119"]);
+        expect_eq(eval.width(), expect!["107"]);
         expect_eq(eval_comm_unop.width(), expect!["71"]);
         expect_eq(eval_hide.width(), expect!["76"]);
         expect_eq(eval_unop.width(), expect!["33"]);
@@ -1483,13 +1483,13 @@ mod test {
         expect_eq(eval_let.width(), expect!["54"]);
         expect_eq(eval_letrec.width(), expect!["58"]);
         expect_eq(equal.width(), expect!["44"]);
-        expect_eq(equal_inner.width(), expect!["63"]);
+        expect_eq(equal_inner.width(), expect!["53"]);
         expect_eq(car_cdr.width(), expect!["34"]);
         expect_eq(apply.width(), expect!["60"]);
         expect_eq(env_lookup.width(), expect!["47"]);
-        expect_eq(ingress.width(), expect!["102"]);
+        expect_eq(ingress.width(), expect!["97"]);
         expect_eq(ingress_builtin.width(), expect!["46"]);
-        expect_eq(egress.width(), expect!["73"]);
+        expect_eq(egress.width(), expect!["68"]);
         expect_eq(egress_builtin.width(), expect!["39"]);
         expect_eq(hash_24_8.width(), expect!["485"]);
         expect_eq(hash_32_8.width(), expect!["647"]);


### PR DESCRIPTION
This PR optimizes patterns such as `0, 1, 2 => { ... }`  in Lair. This has resulted in 14 less selector columns in eval.

The way I've achieved this is by breaking the match statement into smaller operations. Now, the backend explicitly verifies the correct branch using operations such as `assert_eq!`, `assert_ne!` (for default branches), and `contains!` (used when there are multiple patterns for the same branch). The backend now has a non-deterministic `choose` statement that simply jumps without verifying anything. It is the compiler who has the responsibility of correctly adding the assert operations to properly constrain the jumps

There's one caveat. The optimization for equal branches only works on matches of single statements. That's because to verify that `x` is in `[a1, ... an]` it's enough to verify that `(x-a1)*...*(x-an) = 0`. In the case of arrays it's a bit more complicated and will require linear combinations and boolean constraints. I didn't think it was necessary (yet).

Now, the way I did this is simple. In the frontend, I group all field elements that map to the same branch in a vector, which pairs with their branch. The compiler then produces a branch for each group, and produces a `contains!(set, x)` operation which verifies that the matched variable `x` is within the set of possibilities. The bytecode keeps track both of the map of field elements to branches, and the vector of unique branches. When doing trace generation and execute, I use the map to select the correct branch and continue. When doing eval, I must go through all the *unique* branches, so I use the vector of branches. It's a bit annoying that I'm cloning the branches to both be in the map and the vector. There are some possibilities here:

1) use Arc. This is simple, but will introduce a bit of overhead on accessing (one more pointer chase)
2) map field elements to indices, use the indices to access the vector of unique branch. This also increases the pointer chase (but will probably be in cache), but what's worse is that this will require modifying the `Cases` struct, used for `ChooseMany` as well
3) use indices in the vector of unique branches. This would be a really nice solution, if it wasn't for the fact that you compute the indices in order of insertion, not in order of the map, which performs a sort based on the field elements