### PR TITLE
feat: memoize Lurk data into ZStore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ match_opt = "0.1.2"
 nom = "7.1.3"
 nom_locate = "4.1.0"
 num-bigint = "0.4.3"
+num-derive = "0.3"
+num-traits = "0.2"
 once_cell = "1.18.0"
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"
@@ -71,6 +73,8 @@ match_opt = { workspace = true }
 nom = { workspace = true }
 nom_locate = { workspace = true }
 num-bigint = { workspace = true }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -72,7 +72,7 @@ fn setup<H: Hasher<BabyBear>>(
 fn evaluation(c: &mut Criterion) {
     let arg = get_fib_arg();
     c.bench_function(&format!("evaluation-{arg}"), |b| {
-        let toplevel = build_lurk_toplevel();
+        let (toplevel, _) = build_lurk_toplevel();
         let (args, lurk_main, record) = setup(arg, &toplevel);
         b.iter_batched(
             || (args.clone(), record.clone()),
@@ -87,7 +87,7 @@ fn evaluation(c: &mut Criterion) {
 fn trace_generation(c: &mut Criterion) {
     let arg = get_fib_arg();
     c.bench_function(&format!("trace-generation-{arg}"), |b| {
-        let toplevel = build_lurk_toplevel();
+        let (toplevel, _) = build_lurk_toplevel();
         let (args, lurk_main, mut record) = setup(arg, &toplevel);
         toplevel.execute(lurk_main.func(), &args, &mut record);
         let lair_chips = build_lair_chip_vector(&lurk_main);
@@ -103,7 +103,7 @@ fn trace_generation(c: &mut Criterion) {
 fn e2e(c: &mut Criterion) {
     let arg = get_fib_arg();
     c.bench_function(&format!("e2e-{arg}"), |b| {
-        let toplevel = build_lurk_toplevel();
+        let (toplevel, _) = build_lurk_toplevel();
         let (args, lurk_main, record) = setup(arg, &toplevel);
 
         b.iter_batched(

--- a/src/lair/execute.rs
+++ b/src/lair/execute.rs
@@ -347,6 +347,17 @@ impl<F: PrimeField32> QueryRecord<F> {
         }
     }
 
+    pub fn get_inv_queries<H: Hasher<F>>(
+        &self,
+        name: &'static str,
+        toplevel: &Toplevel<F, H>,
+    ) -> &InvQueryMap<F> {
+        let func = toplevel.get_by_name(name);
+        self.inv_func_queries[func.index]
+            .as_ref()
+            .expect("Inverse query map not found")
+    }
+
     /// Erases the records of func and memory queries, but leaves the history of
     /// invertible queries untouched
     pub fn clean(&mut self) {

--- a/src/lair/hasher.rs
+++ b/src/lair/hasher.rs
@@ -29,6 +29,7 @@ pub trait Hasher<F>: Default + Sync {
     );
 }
 
+#[derive(Clone)]
 pub struct LurkHasher {
     hasher_24_8: Poseidon2<
         BabyBear,

--- a/src/lurk/tag.rs
+++ b/src/lurk/tag.rs
@@ -1,8 +1,12 @@
-use p3_field::AbstractField;
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use p3_field::{AbstractField, PrimeField32};
 use serde::{Deserialize, Serialize};
 
 #[repr(u32)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, FromPrimitive,
+)]
 pub enum Tag {
     Nil = 0,
     Cons,
@@ -21,7 +25,13 @@ pub enum Tag {
 }
 
 impl Tag {
+    #[inline]
     pub fn to_field<F: AbstractField>(self) -> F {
-        F::from_canonical_u16(self as u16)
+        F::from_canonical_u32(self as u32)
+    }
+
+    #[inline]
+    pub fn from_field<F: PrimeField32>(f: &F) -> Tag {
+        Tag::from_u32(f.as_canonical_u32()).expect("Field element doesn't map to a Tag")
     }
 }


### PR DESCRIPTION
After execution, we need to gather data from Lair's `QueryRecord` in order to reconstruct the Lurk data the `lurk_main` function (opaquely) outputs.