### PR TITLE
feat: add distill phase to `loam!`

### DIFF
--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -25,9 +25,10 @@ ascent! {
 }
 
 loam! {
-    struct LoamProgram;
+    struct FibProgram;
 
     // Facts:
+    // #[distill(preserve)]
     relation number(isize);
 
     // Rules:
@@ -48,11 +49,11 @@ fn main() {
 
     let AscentProgram { mut fib_table, .. } = ascent_prog;
 
-    let mut loam_prog = LoamProgram::default();
+    let mut loam_prog = FibProgram::default();
     loam_prog.number = (0..6).map(|n| (n,)).collect();
     loam_prog.run();
 
-    let LoamProgram {
+    let FibProgram {
         mut fib_table_2, ..
     } = loam_prog;
 
@@ -63,5 +64,14 @@ fn main() {
     println!("{:?}", fib_table_2);
 
     assert_eq!(fib_table, fib_table_2);
-    println!("success!")
+    println!("success!");
+
+    let mut distilled_program = DistilledFibProgram::default();
+    distilled_program.number = (0..6).map(|n| (n,)).collect();
+    distilled_program.fib = vec![(0, 1), (1, 1)];
+    distilled_program.run();
+
+    let DistilledFibProgram { fib, .. } = distilled_program;
+
+    println!("fib: {:?}", fib);
 }

--- a/loam-macros/src/lib.rs
+++ b/loam-macros/src/lib.rs
@@ -3,7 +3,7 @@ mod loam_syntax;
 #[macro_use]
 extern crate quote;
 
-use loam_syntax::{compile_new_ascent_to_ascent, LoamProgram};
+use loam_syntax::{compile_loam_to_ascent, LoamProgram};
 
 /// Wrapper around the `ascent!` macro.
 ///
@@ -11,5 +11,5 @@ use loam_syntax::{compile_new_ascent_to_ascent, LoamProgram};
 #[proc_macro]
 pub fn loam(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let new_prog: LoamProgram = syn::parse_macro_input!(input as LoamProgram);
-    compile_new_ascent_to_ascent(new_prog).into()
+    compile_loam_to_ascent(new_prog).into()
 }


### PR DESCRIPTION
The `loam!` macro now expands into two programs: the first "elaborated" program with expanded bindings, and then the second "distilled" program with non-binding rules removed. For example,
```rust
loam! {
    struct FibProgram;

    // Facts:
    // #[distill(preserve)]
    relation number(isize);

    // Rules:
    relation fib(isize, isize);

    #[with_bindings(this_does_nothing)]
    fib(0, 1) <-- number(0);
    fib(1, 1) <-- number(1);

    #[with_bindings(fib_table_2)]
    fib(x, y + z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
}
```
expands into the distilled program:
```rust
ascent! {
    struct DistilledFibProgram;

    // Facts:
    relation number(isize);

    // Rules:
    relation fib(isize, isize);

    fib(x, y + z) <-- number(x), if *x >= 2, fib(x - 1, y), fib(x - 2, z);
}
```

## Notes
- Implemented a `#[distill(preserve)]` tag that stops the distilled program from dropping certain rules, for debugging.
- For an ascent program named `X`, we automatically generate the distilled program `DistilledX`.