### PR TITLE
chore: commitment-related builtins

### DIFF
--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -129,6 +129,14 @@ impl<F: AbstractField + Copy> ZPtr<F> {
             digest: digest_from_field(err.to_field()),
         }
     }
+
+    #[inline]
+    pub fn comm(digest: [F; DIGEST_SIZE]) -> Self {
+        Self {
+            tag: Tag::Comm,
+            digest,
+        }
+    }
 }
 
 impl<F: AbstractField + Copy> ZPtr<F> {


### PR DESCRIPTION
* Egress pointers before hashing
* Ingress digest to get Comm pointers
* Secret for `commit` is just 8 zeros
* `hide` requires a commitment as a secret
* `secret` returns the commitment that was used as a secret

Closes #63