### PR TITLE
chore: Upgrade test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ concurrency:
 
 jobs:
   test:
-    # Change to warp-ubuntu-latest-x64-16x for a more powerful runner
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - name: Set up git private repo access
         run: |


### PR DESCRIPTION
CI is starting to take longer as we add more features and tests, such as #26, so this PR upgrades to a larger runner for the `test` job.

Before: [8 minutes](https://github.com/lurk-lab/loam/actions/runs/9993418810/job/27620722055)
After: [2 minutes](https://github.com/lurk-lab/loam/actions/runs/9993614910/job/27621383970?pr=159)