### PR TITLE
Loam feature granularity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ pub mod lair;
 // #[allow(dead_code)]
 // pub mod logup;
 
-#[cfg(feature = "loam")]
 pub mod loam;
 
 #[allow(dead_code)]

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -155,6 +155,7 @@ impl Allocator {
     }
 }
 
+#[cfg(feature = "loam")]
 ascent! {
     struct AllocationProgram;
 
@@ -353,6 +354,7 @@ ascent! {
     ////////////////////////////////////////////////////////////////////////////////
 }
 
+#[cfg(feature = "loam")]
 impl AllocationProgram {
     fn cons_mem_is_contiguous(&self) -> bool {
         let mut addrs1 = self
@@ -392,6 +394,7 @@ impl AllocationProgram {
 }
 
 #[cfg(test)]
+#[cfg(feature = "loam")]
 mod test {
     use super::*;
 

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -184,8 +184,9 @@ impl Tag {
     }
 }
 
-// Because it's hard to share code between ascent programs, this is a copy of `AllocationProgram`, replacing the `map_double` function
-// with evaluation.
+// Because it's hard to share code between ascent programs, this is a copy of `AllocationProgam`, replacing the `map_double` function
+// with evaluation
+#[cfg(feature = "loam")]
 ascent! {
     struct EvaluationProgram;
 
@@ -968,6 +969,7 @@ ascent! {
 }
 
 #[cfg(test)]
+#[cfg(feature = "loam")]
 mod test {
     use super::*;
     use crate::lurk::zstore::ZPtr;


### PR DESCRIPTION
This PR changes the loam feature to only cover the Loam programs themselves (which account for the majority of compilation time). Consequently, development without the loam feature activated will still typecheck supporting code used by the Loam programs.