### PR TITLE
chore: Remove swap in reduce_aux

### DIFF
--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -143,10 +143,7 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
             &self.build_input(expr),
             &mut queries,
         ));
-        std::mem::swap(
-            &mut self.queries.inv_func_queries,
-            &mut queries.inv_func_queries,
-        );
+        self.queries.inv_func_queries = queries.inv_func_queries;
         output
     }
 


### PR DESCRIPTION
It seems to work fine like this, no need for a destructure or take