### PR TITLE
chore: chip witness holds output

### DIFF
--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -353,24 +353,22 @@ impl<F: Field> Op<F> {
                 let input: Vec<_> = input.iter().map(|a| map[*a].to_expr()).collect();
                 let chip = toplevel.get_chip_by_index(*chip_idx);
 
-                // order: output, witness, requires
-                let output_vars = local.next_n_aux(index, chip.output_size());
+                // order: witness, requires
                 let witness = local.next_n_aux(index, chip.witness_size());
                 let requires = (0..chip.require_size())
                     .map(|_| local.next_require(index))
                     .collect::<Vec<_>>();
 
-                chip.eval(
+                let output_vars = chip.eval(
                     builder,
                     sel.clone(),
                     input,
-                    output_vars,
                     witness,
                     (*local.nonce).into(),
                     &requires,
                 );
-                for &img_var in output_vars {
-                    map.push(Val::Expr(img_var.into()))
+                for img_var in output_vars {
+                    map.push(Val::Expr(img_var))
                 }
             }
             Op::Debug(..) => (),

--- a/src/lair/chipset.rs
+++ b/src/lair/chipset.rs
@@ -39,11 +39,10 @@ pub trait Chipset<F>: Sync {
         builder: &mut AB,
         is_real: AB::Expr,
         input: Vec<AB::Expr>,
-        output: &[AB::Var],
         witness: &[AB::Var],
-        _nonce: AB::Expr,
-        _requires: &[RequireRecord<AB::Var>],
-    );
+        nonce: AB::Expr,
+        requires: &[RequireRecord<AB::Var>],
+    ) -> Vec<AB::Expr>;
 }
 
 pub struct Nochip;
@@ -79,10 +78,9 @@ impl<F> Chipset<F> for Nochip {
         _: AB::Expr,
         _: Vec<AB::Expr>,
         _: &[AB::Var],
-        _: &[AB::Var],
         _: AB::Expr,
         _: &[RequireRecord<AB::Var>],
-    ) {
+    ) -> Vec<AB::Expr> {
         unimplemented!()
     }
 }

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -266,10 +266,9 @@ impl<F> Op<F> {
             }
             Op::ExternCall(chip_idx, _) => {
                 let chip = toplevel.get_chip_by_index(*chip_idx);
-                let output_size = chip.output_size();
                 let require_size = chip.require_size();
                 let witness_size = chip.witness_size();
-                let aux_size = output_size + witness_size + require_size * 3;
+                let aux_size = witness_size + require_size * 3;
                 *aux += aux_size;
                 degrees.extend(vec![1; aux_size]);
             }

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -338,13 +338,13 @@ impl<F: PrimeField32> Op<F> {
 
                 let input = input.iter().map(|a| map[*a].0).collect::<List<_>>();
                 let mut witness = vec![F::zero(); chip.witness_size()];
-                let out = chip.populate_witness(&input, &mut witness);
 
-                // order: output, witness, requires
+                let out = chip.populate_witness(&input, &mut witness);
                 for f in out {
                     map.push((f, 1));
-                    slice.push_aux(index, f);
                 }
+
+                // order: witness, requires
                 for f in witness {
                     slice.push_aux(index, f);
                 }

--- a/src/lurk/chipset.rs
+++ b/src/lurk/chipset.rs
@@ -1,59 +1,29 @@
 use p3_air::AirBuilder;
 use p3_baby_bear::BabyBear;
-use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
-use p3_symmetric::Permutation;
 
 use crate::{
     air::builder::{LookupBuilder, Record, RequireRecord},
     lair::{chipset::Chipset, execute::QueryRecord},
-    poseidon::{
-        config::{
-            BabyBearConfig24, BabyBearConfig32, BabyBearConfig48, InternalDiffusion, PoseidonConfig,
-        },
-        wide::{air::eval_input, columns::Poseidon2Cols, trace::populate_witness},
-    },
+    poseidon::config::{BabyBearConfig24, BabyBearConfig32, BabyBearConfig48},
 };
 
 use crate::lair::{map::Map, Name};
+use crate::lurk::poseidon::PoseidonChipset;
 
 use super::{u64::U64, zstore::Hasher};
 
 #[derive(Clone)]
 pub enum LurkChip {
-    Hasher24_8(
-        Poseidon2<
-            BabyBear,
-            Poseidon2ExternalMatrixGeneral,
-            InternalDiffusion<BabyBearConfig24>,
-            24,
-            7,
-        >,
-    ),
-    Hasher32_8(
-        Poseidon2<
-            BabyBear,
-            Poseidon2ExternalMatrixGeneral,
-            InternalDiffusion<BabyBearConfig32>,
-            32,
-            7,
-        >,
-    ),
-    Hasher48_8(
-        Poseidon2<
-            BabyBear,
-            Poseidon2ExternalMatrixGeneral,
-            InternalDiffusion<BabyBearConfig48>,
-            48,
-            7,
-        >,
-    ),
+    Hasher24_8(PoseidonChipset<BabyBearConfig24, 24>),
+    Hasher32_8(PoseidonChipset<BabyBearConfig32, 32>),
+    Hasher48_8(PoseidonChipset<BabyBearConfig48, 48>),
     U64(U64),
 }
 
 pub fn lurk_chip_map() -> Map<Name, LurkChip> {
-    let hash_24_8 = LurkChip::Hasher24_8(BabyBearConfig24::hasher());
-    let hash_32_8 = LurkChip::Hasher32_8(BabyBearConfig32::hasher());
-    let hash_48_8 = LurkChip::Hasher48_8(BabyBearConfig48::hasher());
+    let hash_24_8 = LurkChip::Hasher24_8(PoseidonChipset::default());
+    let hash_32_8 = LurkChip::Hasher32_8(PoseidonChipset::default());
+    let hash_48_8 = LurkChip::Hasher48_8(PoseidonChipset::default());
     let u64_add = LurkChip::U64(U64::Add);
     let u64_sub = LurkChip::U64(U64::Sub);
     let u64_mul = LurkChip::U64(U64::Mul);
@@ -72,19 +42,13 @@ pub fn lurk_chip_map() -> Map<Name, LurkChip> {
     Map::from_vec(vec)
 }
 
-macro_rules! sized {
-    ($vector:ident) => {
-        $vector.try_into().unwrap()
-    };
-}
-
 impl Chipset<BabyBear> for LurkChip {
     #[inline]
     fn input_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(..) => 24,
-            LurkChip::Hasher32_8(..) => 32,
-            LurkChip::Hasher48_8(..) => 48,
+            LurkChip::Hasher24_8(op) => op.input_size(),
+            LurkChip::Hasher32_8(op) => op.input_size(),
+            LurkChip::Hasher48_8(op) => op.input_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::input_size(op),
         }
     }
@@ -92,32 +56,36 @@ impl Chipset<BabyBear> for LurkChip {
     #[inline]
     fn output_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(..) | LurkChip::Hasher32_8(..) | LurkChip::Hasher48_8(..) => 8,
+            LurkChip::Hasher24_8(op) => op.output_size(),
+            LurkChip::Hasher32_8(op) => op.output_size(),
+            LurkChip::Hasher48_8(op) => op.output_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::output_size(op),
         }
     }
 
     fn witness_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(..) => Poseidon2Cols::<BabyBear, BabyBearConfig24, 24>::num_cols(),
-            LurkChip::Hasher32_8(..) => Poseidon2Cols::<BabyBear, BabyBearConfig32, 32>::num_cols(),
-            LurkChip::Hasher48_8(..) => Poseidon2Cols::<BabyBear, BabyBearConfig48, 48>::num_cols(),
+            LurkChip::Hasher24_8(op) => op.witness_size(),
+            LurkChip::Hasher32_8(op) => op.witness_size(),
+            LurkChip::Hasher48_8(op) => op.witness_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::witness_size(op),
         }
     }
 
     fn require_size(&self) -> usize {
         match self {
-            LurkChip::Hasher24_8(..) | LurkChip::Hasher32_8(..) | LurkChip::Hasher48_8(..) => 0,
+            LurkChip::Hasher24_8(op) => op.require_size(),
+            LurkChip::Hasher32_8(op) => op.require_size(),
+            LurkChip::Hasher48_8(op) => op.require_size(),
             LurkChip::U64(op) => <U64 as Chipset<BabyBear>>::require_size(op),
         }
     }
 
-    fn execute_simple(&self, preimg: &[BabyBear]) -> Vec<BabyBear> {
+    fn execute_simple(&self, input: &[BabyBear]) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher24_8(hash) => hash.permute(sized!(preimg))[..self.output_size()].into(),
-            LurkChip::Hasher32_8(hash) => hash.permute(sized!(preimg))[..self.output_size()].into(),
-            LurkChip::Hasher48_8(hash) => hash.permute(sized!(preimg))[..self.output_size()].into(),
+            LurkChip::Hasher24_8(hasher) => hasher.execute_simple(input),
+            LurkChip::Hasher32_8(hasher) => hasher.execute_simple(input),
+            LurkChip::Hasher48_8(hasher) => hasher.execute_simple(input),
             LurkChip::U64(..) => panic!("use `execute`"),
         }
     }
@@ -130,33 +98,18 @@ impl Chipset<BabyBear> for LurkChip {
         requires: &mut Vec<Record>,
     ) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher24_8(hash) => hash.permute(sized!(input))[..self.output_size()].into(),
-            LurkChip::Hasher32_8(hash) => hash.permute(sized!(input))[..self.output_size()].into(),
-            LurkChip::Hasher48_8(hash) => hash.permute(sized!(input))[..self.output_size()].into(),
+            LurkChip::Hasher24_8(hasher) => hasher.execute(input, nonce, queries, requires),
+            LurkChip::Hasher32_8(hasher) => hasher.execute(input, nonce, queries, requires),
+            LurkChip::Hasher48_8(hasher) => hasher.execute(input, nonce, queries, requires),
             LurkChip::U64(op) => op.execute(input, nonce, queries, requires),
         }
     }
 
     fn populate_witness(&self, input: &[BabyBear], witness: &mut [BabyBear]) -> Vec<BabyBear> {
         match self {
-            LurkChip::Hasher24_8(..) => {
-                let mut out: Vec<_> =
-                    populate_witness::<BabyBearConfig24, 24>(sized!(input), witness).into();
-                out.truncate(8);
-                out
-            }
-            LurkChip::Hasher32_8(..) => {
-                let mut out: Vec<_> =
-                    populate_witness::<BabyBearConfig32, 32>(sized!(input), witness).into();
-                out.truncate(8);
-                out
-            }
-            LurkChip::Hasher48_8(..) => {
-                let mut out: Vec<_> =
-                    populate_witness::<BabyBearConfig48, 48>(sized!(input), witness).into();
-                out.truncate(8);
-                out
-            }
+            LurkChip::Hasher24_8(hasher) => hasher.populate_witness(input, witness),
+            LurkChip::Hasher32_8(hasher) => hasher.populate_witness(input, witness),
+            LurkChip::Hasher48_8(hasher) => hasher.populate_witness(input, witness),
             LurkChip::U64(op) => op.populate_witness(input, witness),
         }
     }
@@ -166,34 +119,21 @@ impl Chipset<BabyBear> for LurkChip {
         builder: &mut AB,
         is_real: AB::Expr,
         preimg: Vec<AB::Expr>,
-        img: &[AB::Var],
         witness: &[AB::Var],
         nonce: AB::Expr,
         requires: &[RequireRecord<AB::Var>],
-    ) {
+    ) -> Vec<AB::Expr> {
         match self {
-            LurkChip::Hasher24_8(..) => eval_input::<AB, BabyBearConfig24, 24>(
-                builder,
-                sized!(preimg),
-                img,
-                witness,
-                is_real,
-            ),
-            LurkChip::Hasher32_8(..) => eval_input::<AB, BabyBearConfig32, 32>(
-                builder,
-                sized!(preimg),
-                img,
-                witness,
-                is_real,
-            ),
-            LurkChip::Hasher48_8(..) => eval_input::<AB, BabyBearConfig48, 48>(
-                builder,
-                sized!(preimg),
-                img,
-                witness,
-                is_real,
-            ),
-            LurkChip::U64(op) => op.eval(builder, is_real, preimg, img, witness, nonce, requires),
+            LurkChip::Hasher24_8(hasher) => {
+                hasher.eval(builder, is_real, preimg, witness, nonce, requires)
+            }
+            LurkChip::Hasher32_8(hasher) => {
+                hasher.eval(builder, is_real, preimg, witness, nonce, requires)
+            }
+            LurkChip::Hasher48_8(hasher) => {
+                hasher.eval(builder, is_real, preimg, witness, nonce, requires)
+            }
+            LurkChip::U64(op) => op.eval(builder, is_real, preimg, witness, nonce, requires),
         }
     }
 }
@@ -203,8 +143,8 @@ pub type LurkHasher = Hasher<BabyBear, LurkChip>;
 #[inline]
 pub fn lurk_hasher() -> LurkHasher {
     Hasher::new(
-        LurkChip::Hasher24_8(BabyBearConfig24::hasher()),
-        LurkChip::Hasher32_8(BabyBearConfig32::hasher()),
-        LurkChip::Hasher48_8(BabyBearConfig48::hasher()),
+        LurkChip::Hasher24_8(PoseidonChipset::default()),
+        LurkChip::Hasher32_8(PoseidonChipset::default()),
+        LurkChip::Hasher48_8(PoseidonChipset::default()),
     )
 }

--- a/src/lurk/mod.rs
+++ b/src/lurk/mod.rs
@@ -7,6 +7,7 @@ pub mod eval;
 mod eval_tests;
 pub mod package;
 pub mod parser;
+pub mod poseidon;
 pub mod state;
 pub mod symbol;
 pub mod syntax;

--- a/src/lurk/poseidon.rs
+++ b/src/lurk/poseidon.rs
@@ -1,0 +1,94 @@
+use crate::air::builder::{LookupBuilder, RequireRecord};
+use crate::lair::chipset::Chipset;
+use crate::poseidon::config::{InternalDiffusion, PoseidonConfig};
+use crate::poseidon::wide::columns::Poseidon2Cols;
+use hybrid_array::typenum::Sub1;
+use hybrid_array::ArraySize;
+use p3_air::AirBuilder;
+
+use p3_field::AbstractField;
+use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
+use p3_symmetric::Permutation;
+use std::borrow::{Borrow, BorrowMut};
+
+const OUTPUT_SIZE: usize = 8;
+
+#[derive(Clone)]
+pub struct PoseidonChipset<C: PoseidonConfig<W>, const W: usize> {
+    hasher: Poseidon2<C::F, Poseidon2ExternalMatrixGeneral, InternalDiffusion<C>, W, 7>,
+}
+
+impl<C: PoseidonConfig<W>, const W: usize> Default for PoseidonChipset<C, W> {
+    fn default() -> Self {
+        Self {
+            hasher: C::hasher(),
+        }
+    }
+}
+
+impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> PoseidonChipset<C, WIDTH> {
+    pub fn hash(&self, preimg: &[C::F]) -> [C::F; OUTPUT_SIZE] {
+        let mut state = [C::F::zero(); WIDTH];
+        state.copy_from_slice(preimg);
+        self.hasher.permute_mut(&mut state);
+
+        let mut out = [C::F::zero(); OUTPUT_SIZE];
+        out.copy_from_slice(&state[..OUTPUT_SIZE]);
+        out
+    }
+}
+
+impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> Chipset<C::F> for PoseidonChipset<C, WIDTH>
+where
+    Sub1<C::R_P>: ArraySize,
+{
+    fn input_size(&self) -> usize {
+        WIDTH
+    }
+
+    fn output_size(&self) -> usize {
+        OUTPUT_SIZE
+    }
+
+    fn witness_size(&self) -> usize {
+        OUTPUT_SIZE + Poseidon2Cols::<C::F, C, WIDTH>::num_cols()
+    }
+
+    fn require_size(&self) -> usize {
+        0
+    }
+
+    fn execute_simple(&self, input: &[C::F]) -> Vec<C::F> {
+        self.hasher.permute(input.try_into().unwrap())[..OUTPUT_SIZE].to_vec()
+    }
+
+    fn populate_witness(&self, input: &[C::F], witness: &mut [C::F]) -> Vec<C::F> {
+        let (output, witness) = witness.split_at_mut(OUTPUT_SIZE);
+
+        let cols: &mut Poseidon2Cols<C::F, C, WIDTH> = witness.borrow_mut();
+        let result = cols.populate(input.try_into().unwrap());
+        output.copy_from_slice(&result[0..OUTPUT_SIZE]);
+        result.to_vec()
+    }
+
+    /// Given a witness of size `OUTPUT_SIZE + Poseidon2Cols::num_cols`,
+    /// apply the Poseidon2 permutation over the input and compare the returned state,
+    /// potentially truncating it to the image size.
+    /// When is_real = 0, the output is unconstrained.
+    fn eval<AB: AirBuilder<F = C::F> + LookupBuilder>(
+        &self,
+        builder: &mut AB,
+        is_real: AB::Expr,
+        input: Vec<AB::Expr>,
+        witness: &[AB::Var],
+        _nonce: AB::Expr,
+        _requires: &[RequireRecord<AB::Var>],
+    ) -> Vec<AB::Expr> {
+        let (output, witness) = witness.split_at(OUTPUT_SIZE);
+
+        let cols: &Poseidon2Cols<AB::Var, C, WIDTH> = witness.borrow();
+        cols.eval(builder, input.try_into().unwrap(), output, is_real);
+
+        output.iter().copied().map(Into::into).collect()
+    }
+}

--- a/src/poseidon/wide/air.rs
+++ b/src/poseidon/wide/air.rs
@@ -6,25 +6,7 @@ use p3_air::AirBuilder;
 use p3_field::AbstractField;
 use p3_symmetric::Permutation;
 
-use std::borrow::Borrow;
 use std::iter::zip;
-
-/// Given a witness of size `Poseidon2Cols::num_cols` and an expected output digest,
-/// apply the Poseidon2 permutation over the input and compare the returned state,
-/// potentially truncating it to the image size.
-/// When is_real = 0, the output is unconstrained.
-pub fn eval_input<AB: AirBuilder, C: PoseidonConfig<WIDTH, F = AB::F>, const WIDTH: usize>(
-    builder: &mut AB,
-    input: [AB::Expr; WIDTH],
-    output: &[AB::Var],
-    witness: &[AB::Var],
-    is_real: AB::Expr,
-) where
-    Sub1<C::R_P>: ArraySize,
-{
-    let cols: &Poseidon2Cols<AB::Var, C, WIDTH> = witness.borrow();
-    cols.eval(builder, input, output, is_real);
-}
 
 impl<T, C: PoseidonConfig<WIDTH>, const WIDTH: usize> Poseidon2Cols<T, C, WIDTH>
 where

--- a/src/poseidon/wide/trace.rs
+++ b/src/poseidon/wide/trace.rs
@@ -3,19 +3,7 @@ use crate::poseidon::wide::columns::Poseidon2Cols;
 use hybrid_array::{typenum::Sub1, ArraySize};
 use p3_field::AbstractField;
 use p3_symmetric::Permutation;
-use std::borrow::BorrowMut;
 use std::iter::zip;
-
-pub fn populate_witness<C: PoseidonConfig<WIDTH>, const WIDTH: usize>(
-    input: [C::F; WIDTH],
-    witness: &mut [C::F],
-) -> [C::F; WIDTH]
-where
-    Sub1<C::R_P>: ArraySize,
-{
-    let cols: &mut Poseidon2Cols<C::F, C, WIDTH> = witness.borrow_mut();
-    cols.populate(input)
-}
 
 impl<C: PoseidonConfig<WIDTH>, const WIDTH: usize> Poseidon2Cols<C::F, C, WIDTH>
 where


### PR DESCRIPTION
Changes the interface of `Chipset` so that the witness must contain the output. This ensures removes the duplicated columns from #163.

This PR moves some lurk-specific functions from the poseidon module to lurk/poseidon, and implements Chipset for it. 

It would be nice if the `Hasher` was its own construct rather than depending on `Chipset`