### PR TITLE
feat: Add defrec and clear meta commands

### DIFF
--- a/src/lurk/cli/meta.rs
+++ b/src/lurk/cli/meta.rs
@@ -78,11 +78,23 @@ impl<F: PrimeField32, H: Chipset<F>> MetaCmd<F, H> {
             Ok(())
         },
     };
+
+    const CLEAR: Self = Self {
+        name: "clear",
+        summary: "Reset the current environment to be empty.",
+        format: "!(clear)",
+        description: &[],
+        example: &["!(def a 1)", "(current-env)", "!(clear)", "(current-env)"],
+        run: |repl, _args, _path| {
+            repl.env = repl.zstore.intern_empty_env();
+            Ok(())
+        },
+    };
 }
 
 #[inline]
 pub(crate) fn meta_cmds<F: PrimeField32, H: Chipset<F>>() -> MetaCmdsMap<F, H> {
-    [MetaCmd::DEF, MetaCmd::DEFREC]
+    [MetaCmd::DEF, MetaCmd::DEFREC, MetaCmd::CLEAR]
         .map(|mc| (mc.name, mc))
         .into_iter()
         .collect()


### PR DESCRIPTION
This adds support for the `!(defrec)` and `!(clear)` meta commands:

```
user> !(defrec sum (lambda (l) (if (eq l nil) 0 (+ (car l) (sum (cdr l))))))
sum
user> !(def xs '(100 200 300 400))
xs
user> (current-env)
[1 iteration] => <Env ((xs . (100 200 300 400)) (sum . <Thunk (lambda (l) (if (eq l nil) 0 (+ (car l) (sum (cdr l)))))>))>
user> (sum xs)
[45 iterations] => 1000
user> !(clear)
user> (current-env)
[1 iteration] => <Env ()>
```