### PR TITLE
feat: `prove` and `verify` meta commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = "1.0.72"
 ascent = "0.6.0"
 arc-swap = "1.7.1"
 base-x = "0.2.11"
+bincode = "1"
 camino = "1.1"
 criterion = "0.5"
 elsa = { git = "https://github.com/argumentcomputer/elsa", branch = "sync_frozen" }
@@ -69,6 +70,7 @@ anyhow = { workspace = true }
 ascent = { workspace = true }
 arc-swap = { workspace = true }
 base-x = { workspace = true }
+bincode = { workspace = true }
 camino = { workspace = true }
 elsa = { workspace = true, features = ["indexmap"] }
 expect-test = { workspace = true }

--- a/src/lurk/cli/paths.rs
+++ b/src/lurk/cli/paths.rs
@@ -21,6 +21,12 @@ pub(crate) fn lurk_dir() -> Result<&'static Utf8PathBuf> {
 }
 
 #[inline]
+pub(crate) fn proofs_dir() -> Result<Utf8PathBuf> {
+    let proofs_dir_path = get_config().lurk_dir.join("proofs");
+    create_dir_all_and_return(proofs_dir_path)
+}
+
+#[inline]
 pub(crate) fn repl_history() -> Result<Utf8PathBuf> {
     Ok(lurk_dir()?.join("repl-history"))
 }

--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -37,9 +37,9 @@ impl Validator for InputValidator {
 
 pub(crate) struct Repl<F: PrimeField32, H: Chipset<F>> {
     pub(crate) zstore: ZStore<F, H>,
-    queries: QueryRecord<F>,
-    toplevel: Toplevel<F, H>,
-    lurk_main_idx: usize,
+    pub(crate) queries: QueryRecord<F>,
+    pub(crate) toplevel: Toplevel<F, H>,
+    pub(crate) lurk_main_idx: usize,
     eval_idx: usize,
     pub(crate) env: ZPtr<F>,
     state: StateRcCell,
@@ -77,7 +77,6 @@ fn pretty_iterations_display(iterations: usize) -> String {
 }
 
 impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
-    #[allow(dead_code)]
     pub(crate) fn peek1(&self, args: &ZPtr<F>) -> Result<&ZPtr<F>> {
         if args.tag != Tag::Cons {
             bail!("Missing first argument")
@@ -113,6 +112,7 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
         )
     }
 
+    #[inline]
     pub(crate) fn fmt(&self, zptr: &ZPtr<F>) -> String {
         self.zstore.fmt_with_state(&self.state, zptr)
     }
@@ -147,7 +147,7 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
         output
     }
 
-    fn handle_non_meta(&mut self, expr: &ZPtr<F>) {
+    pub(crate) fn handle_non_meta(&mut self, expr: &ZPtr<F>) {
         self.prepare_queries();
         let output = ZPtr::from_flat_data(&self.toplevel.execute_by_index(
             self.lurk_main_idx,

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -257,6 +257,11 @@ pub(crate) fn builtin_vec() -> &'static Vec<Symbol> {
 }
 
 impl<F: Field, H: Chipset<F>> ZStore<F, H> {
+    #[inline]
+    pub fn hasher(&self) -> &Hasher<F, H> {
+        &self.hasher
+    }
+
     fn hash2(&mut self, preimg: [F; TUPLE2_SIZE]) -> [F; DIGEST_SIZE] {
         if let Some(img) = self.tuple2_hashes.get(&preimg) {
             return *img;


### PR DESCRIPTION
This is a minimal patch towards `prove` and `verify`. There's no data available for `inspect` or `inspect-full` yet.