### PR TITLE
feat: `inspect` meta command

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -56,7 +56,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -60,7 +60,7 @@ fn setup<'a, H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -63,7 +63,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();

--- a/src/loam/allocation.rs
+++ b/src/loam/allocation.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use crate::loam::{LEWrap, Ptr, Wide, WidePtr, LE};
 use crate::lurk::chipset::{lurk_hasher, LurkHasher};
 use crate::lurk::tag::Tag;
-use crate::lurk::zstore::{DIGEST_SIZE, TUPLE2_SIZE};
+use crate::lurk::zstore::{DIGEST_SIZE, HASH4_SIZE};
 
 // Because of how the macros work, it's not easy (or possible) to pass a per-invocation structure like the `Allocator`
 // into the program, while also having access to the program struct itself. However, that access is extremely useful
@@ -59,7 +59,7 @@ impl Allocator {
         self.allocation_map = Default::default();
     }
 
-    pub fn import_hashes(&mut self, hashes: &FxHashMap<[LE; TUPLE2_SIZE], [LE; DIGEST_SIZE]>) {
+    pub fn import_hashes(&mut self, hashes: &FxHashMap<[LE; HASH4_SIZE], [LE; DIGEST_SIZE]>) {
         for (preimage, digest) in hashes {
             let preimage_vec = preimage
                 .chunks(8)

--- a/src/loam/evaluation.rs
+++ b/src/loam/evaluation.rs
@@ -986,7 +986,7 @@ mod test {
         let zstore = &mut lurk_zstore();
         let ZPtr { tag, digest } = zstore.read(src).unwrap();
 
-        allocator().import_hashes(zstore.tuple2_hashes());
+        allocator().import_hashes(&zstore.hashes4);
         wide_ptr(tag.elt(), digest)
     }
 

--- a/src/lurk/cli/io_proof.rs
+++ b/src/lurk/cli/io_proof.rs
@@ -1,0 +1,74 @@
+use p3_baby_bear::BabyBear;
+use serde::{Deserialize, Serialize};
+use sphinx_core::{
+    stark::{MachineProof, StarkGenericConfig, StarkMachine},
+    utils::BabyBearPoseidon2,
+};
+
+use crate::{
+    lair::{
+        chipset::Chipset,
+        lair_chip::{LairChip, LairMachineProgram},
+    },
+    lurk::{
+        tag::Tag,
+        zstore::{ZPtr, ZStore, DIGEST_SIZE, ZPTR_SIZE},
+    },
+};
+
+use super::zdag::ZDag;
+
+type F = BabyBear;
+
+/// Carries a cryptographic proof and the Lurk data needed to make sense of its
+/// public values
+#[derive(Serialize, Deserialize)]
+pub(crate) struct IOProof {
+    sphinx_proof: MachineProof<BabyBearPoseidon2>,
+    pub(crate) expr: ZPtr<F>,
+    pub(crate) env: ZPtr<F>,
+    pub(crate) result: ZPtr<F>,
+    pub(crate) zdag: ZDag<F>,
+}
+
+impl IOProof {
+    pub(crate) fn new<H: Chipset<F>>(
+        sphinx_proof: MachineProof<BabyBearPoseidon2>,
+        public_values: &[F],
+        zstore: &ZStore<F, H>,
+    ) -> Self {
+        let mut zdag = ZDag::default();
+        let expr = ZPtr::from_flat_data(&public_values[..ZPTR_SIZE]);
+        let env =
+            ZPtr::from_flat_digest(Tag::Env, &public_values[ZPTR_SIZE..ZPTR_SIZE + DIGEST_SIZE]);
+        let result = ZPtr::from_flat_data(&public_values[ZPTR_SIZE + DIGEST_SIZE..]);
+        zdag.populate_with_many([&expr, &env, &result], zstore);
+        Self {
+            sphinx_proof,
+            expr,
+            env,
+            result,
+            zdag,
+        }
+    }
+
+    /// Returns `true` if public values are consistent and the proof verifies for
+    /// them. Returns `false` otherwise.
+    pub(crate) fn verify<H: Chipset<F>>(
+        &self,
+        machine: &StarkMachine<BabyBearPoseidon2, LairChip<'_, F, H>>,
+    ) -> bool {
+        let mut public_values = Vec::with_capacity(40);
+        public_values.extend(self.expr.flatten());
+        public_values.extend(self.env.digest);
+        public_values.extend(self.result.flatten());
+        for shard_proof in &self.sphinx_proof.shard_proofs {
+            if shard_proof.public_values != public_values {
+                return false;
+            }
+        }
+        let (_, vk) = machine.setup(&LairMachineProgram);
+        let challenger = &mut machine.config().challenger();
+        machine.verify(&vk, &self.sphinx_proof, challenger).is_ok()
+    }
+}

--- a/src/lurk/cli/mod.rs
+++ b/src/lurk/cli/mod.rs
@@ -1,7 +1,9 @@
 mod config;
+mod io_proof;
 mod meta;
 mod paths;
 pub mod repl;
+mod zdag;
 
 use anyhow::Result;
 use config::{set_config, Config};

--- a/src/lurk/cli/zdag.rs
+++ b/src/lurk/cli/zdag.rs
@@ -1,0 +1,88 @@
+use p3_field::AbstractField;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    lair::chipset::Chipset,
+    lurk::zstore::{ZPtr, ZPtrType, ZStore},
+};
+
+/// Holds Lurk data meant to be persisted and/or shared
+#[derive(Default, Serialize, Deserialize)]
+pub(crate) struct ZDag<F: std::hash::Hash + Eq>(FxHashMap<ZPtr<F>, ZPtrType<F>>);
+
+impl<F: std::hash::Hash + Eq + Copy> ZDag<F> {
+    /// Traverses a ZStore DAG, starting from a given `ZPtr`, while populating
+    /// itself.
+    pub(crate) fn populate_with<'a, H: Chipset<F>>(
+        &mut self,
+        zptr: &'a ZPtr<F>,
+        zstore: &'a ZStore<F, H>,
+        cache: &mut FxHashSet<&'a ZPtr<F>>,
+    ) {
+        if cache.contains(zptr) {
+            return;
+        }
+        let zptr_type = zstore
+            .dag
+            .get(zptr)
+            .expect("Data missing from ZStore's DAG");
+        match zptr_type {
+            ZPtrType::Atom => (),
+            ZPtrType::Tuple2(a, b) | ZPtrType::Compact2(a, b) => {
+                self.populate_with(a, zstore, cache);
+                self.populate_with(b, zstore, cache);
+            }
+            ZPtrType::Tuple3(a, b, c) | ZPtrType::Compact3(a, b, c) => {
+                self.populate_with(a, zstore, cache);
+                self.populate_with(b, zstore, cache);
+                self.populate_with(c, zstore, cache);
+            }
+        }
+        cache.insert(zptr);
+        self.0.insert(*zptr, *zptr_type);
+    }
+
+    /// Calls `populate_with` for a sequence of `ZPtr`s
+    pub(crate) fn populate_with_many<'a, H: Chipset<F>>(
+        &mut self,
+        zptrs: impl IntoIterator<Item = &'a ZPtr<F>>,
+        zstore: &ZStore<F, H>,
+    ) where
+        F: 'a,
+    {
+        let cache = &mut FxHashSet::default();
+        for zptr in zptrs {
+            self.populate_with(zptr, zstore, cache);
+        }
+    }
+
+    /// Moves its data to a target ZStore
+    pub(crate) fn populate_zstore<H: Chipset<F>>(self, zstore: &mut ZStore<F, H>)
+    where
+        F: AbstractField + Copy,
+    {
+        for (zptr, zptr_type) in self.0 {
+            match &zptr_type {
+                ZPtrType::Atom => (),
+                ZPtrType::Tuple2(a, b) => {
+                    zstore.hashes4.insert(ZPtr::flatten2(a, b), zptr.digest);
+                }
+                ZPtrType::Tuple3(a, b, c) => {
+                    zstore.hashes6.insert(ZPtr::flatten3(a, b, c), zptr.digest);
+                }
+                ZPtrType::Compact2(a, b) => {
+                    zstore
+                        .hashes3
+                        .insert(ZPtr::flatten_compact2(a, b), zptr.digest);
+                }
+                ZPtrType::Compact3(a, b, c) => {
+                    zstore
+                        .hashes4
+                        .insert(ZPtr::flatten_compact3(a, b, c), zptr.digest);
+                }
+            }
+            zstore.dag.insert(zptr, zptr_type);
+        }
+    }
+}

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1646,7 +1646,7 @@ mod test {
             let digest: List<_> = digest.into();
 
             let mut queries = QueryRecord::new(toplevel);
-            queries.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+            queries.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
             let mut ingress_args = [F::zero(); 16];
             ingress_args[0] = tag;

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -52,8 +52,9 @@ fn run_test(
     config: BabyBearPoseidon2,
 ) {
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
-    record.inject_inv_queries("hash_48_8", toplevel, zstore.tuple3_hashes());
+    record.inject_inv_queries("hash_24_8", toplevel, &zstore.hashes3);
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
+    record.inject_inv_queries("hash_48_8", toplevel, &zstore.hashes6);
 
     let mut input = [F::zero(); 24];
     input[..16].copy_from_slice(&zptr.flatten());

--- a/src/lurk/parser/position.rs
+++ b/src/lurk/parser/position.rs
@@ -1,7 +1,6 @@
 use std::hash::Hash;
 
 use crate::lurk::parser::Span;
-#[cfg(not(target_arch = "wasm32"))]
 
 /// Source code position of an expression in a file
 #[derive(Clone, Copy, Debug)]

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -278,7 +278,7 @@ pub(crate) const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
     ">=",
 ];
 
-const META_PACKAGE_SYMBOLS_NAMES: [&str; 28] = [
+const META_PACKAGE_SYMBOLS_NAMES: [&str; 27] = [
     "def",
     "defrec",
     "load",
@@ -301,7 +301,6 @@ const META_PACKAGE_SYMBOLS_NAMES: [&str; 28] = [
     "call",
     "chain",
     "inspect",
-    "inspect-full",
     "dump-data",
     "def-load-data",
     "defprotocol",

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -58,7 +58,7 @@ fn setup<H: Chipset<BabyBear>>(
     let ZPtr { tag, digest } = zstore.read(&code).unwrap();
 
     let mut record = QueryRecord::new(toplevel);
-    record.inject_inv_queries("hash_32_8", toplevel, zstore.tuple2_hashes());
+    record.inject_inv_queries("hash_32_8", toplevel, &zstore.hashes4);
 
     let mut full_input = [BabyBear::zero(); 24];
     full_input[0] = tag.to_field();


### PR DESCRIPTION
* Implements `ZDag` to carry Lurk data around;
* Wraps Sphinx proofs with an `IOProof`, meant to carry IO Lurk data
* Fixes DAG memoization for thunks, whose `ZPtrType` is `Compact2`
* Standardize nomenclature for hash-related attributes