### PR TITLE
ci: use PAT for automated PR

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -32,6 +32,7 @@ jobs:
         if: steps.compare-versions.outputs.outdated == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: "${{ secrets.REPO_TOKEN }}"
           branch: "ci-update-rust-version"
           title: "chore: Update Rust version to nightly-${{ env.RUST_VERSION }}"
           commit-message: "chore: Update Rust version to nightly-${{ env.RUST_VERSION }}"


### PR DESCRIPTION
This PR changes the token to be used on automated PR creation from the default `GITHUB_TOKEN` to a PAT. This allows for CI to be triggered on PR creation.