### PR TITLE
feat: `dump-expr` and `load-expr` meta commands

### DIFF
--- a/src/lurk/cli/lurk_data.rs
+++ b/src/lurk/cli/lurk_data.rs
@@ -1,0 +1,34 @@
+use p3_field::AbstractField;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    lair::chipset::Chipset,
+    lurk::zstore::{ZPtr, ZStore},
+};
+
+use super::zdag::ZDag;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct LurkData<F: std::hash::Hash + Eq> {
+    zptr: ZPtr<F>,
+    zdag: ZDag<F>,
+}
+
+impl<F: std::hash::Hash + Eq + Default + Copy> LurkData<F> {
+    #[inline]
+    pub(crate) fn new<H: Chipset<F>>(zptr: ZPtr<F>, zstore: &ZStore<F, H>) -> Self {
+        let mut zdag = ZDag::default();
+        zdag.populate_with(&zptr, zstore, &mut Default::default());
+        Self { zptr, zdag }
+    }
+
+    #[inline]
+    pub(crate) fn populate_zstore<H: Chipset<F>>(self, zstore: &mut ZStore<F, H>) -> ZPtr<F>
+    where
+        F: AbstractField,
+    {
+        let Self { zptr, zdag } = self;
+        zdag.populate_zstore(zstore);
+        zptr
+    }
+}

--- a/src/lurk/cli/mod.rs
+++ b/src/lurk/cli/mod.rs
@@ -1,6 +1,7 @@
 mod comm_data;
 mod config;
 mod io_proof;
+mod lurk_data;
 mod meta;
 mod paths;
 pub mod repl;


### PR DESCRIPTION
These are equivalent to `dump-data` and `def-load-data` from Lurk Beta, just with different names.