### PR TITLE
feat: `set-env`, `help` and package-related meta commands

### DIFF
--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -44,9 +44,9 @@ impl<'a, T> ColumnSlice<'a, T> {
         Self {
             nonce,
             input,
+            output,
             aux,
             sel,
-            output,
         }
     }
 

--- a/src/lair/func_chip.rs
+++ b/src/lair/func_chip.rs
@@ -10,9 +10,9 @@ use super::{
 pub struct ColumnLayout<Value, Slice> {
     pub(crate) nonce: Value,
     pub(crate) input: Slice,
+    pub(crate) output: Slice,
     pub(crate) aux: Slice,
     pub(crate) sel: Slice,
-    pub(crate) output: Slice,
 }
 
 pub type LayoutSizes = ColumnLayout<usize, usize>;

--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -84,9 +84,9 @@ pub(crate) struct Repl<F: PrimeField32, H: Chipset<F>> {
     pub(crate) lurk_main_idx: usize,
     eval_idx: usize,
     pub(crate) env: ZPtr<F>,
-    state: StateRcCell,
+    pub(crate) state: StateRcCell,
     pwd_path: Utf8PathBuf,
-    meta_cmds: MetaCmdsMap<F, H>,
+    pub(crate) meta_cmds: MetaCmdsMap<F, H>,
     pub(crate) nil: ZPtr<F>,
 }
 

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -785,7 +785,7 @@ impl<F: Field, H: Chipset<F>> ZStore<F, H> {
         string
     }
 
-    fn fetch_symbol_path<'a>(&'a self, mut zptr: &'a ZPtr<F>) -> Vec<String>
+    pub fn fetch_symbol_path<'a>(&'a self, mut zptr: &'a ZPtr<F>) -> Vec<String>
     where
         F: PrimeField32,
     {


### PR DESCRIPTION
Also rename the "description" attribute of meta commands to "info", as it suits better.