### PR TITLE
chore: multi-arg `chain`, `call` and `transition`

### DIFF
--- a/demo/bank.lurk
+++ b/demo/bank.lurk
@@ -202,7 +202,7 @@ ledger2
 
 ;; We can verify the proof..
 
-!(verify "184b271f69c4fefce7d065fa3f54bcbf3dfa48350e9e9108abf54e48e810b5")
+!(verify "5723c335ca7728b128b17874b5d76e4ecb7a6019a367ac030009985a3c44b0")
 
 ;; Unfortunately, this functional commitment doesn't let us maintain state.
 ;; Let's turn our single-transaction function into a chained function.
@@ -223,7 +223,7 @@ ledger2
 
 !(prove)
 
-!(verify "80acd89ac50dd36f40b44c85eeb8f7cc23a5d63d348f49e88cdf69a8db6833")
+!(verify "8c6f220f36d3d3627e53730fb4e56234028d1b83dd539edb79c6c6d89f4397")
 
 ;; Then we can transfer 5 more, proceeding from the new head of the chain.
 
@@ -231,7 +231,7 @@ ledger2
 
 !(prove)
 
-!(verify "4ce237460fa2f565d89e94acac4675e1dd87e7650807ea50a4baf02e9e6a88")
+!(verify "435f669b37ca7ff3dd90e0d625d8cdb87b72eeb1182e4d019f57842588b82e")
 
 ;; And once more, this time we'll transfer 20 from Turing to Church.
 
@@ -239,4 +239,4 @@ ledger2
 
 !(prove)
 
-!(verify "1bd6c9bfc2737c71c83230cc662f729b9dce4f85efffb6678c4c79f8c462e3")
+!(verify "9781d2e93cd9fa7103fa10952ed116b53c88ef8300deefe51a33d48244ab8e")

--- a/demo/chained-functional-commitment.lurk
+++ b/demo/chained-functional-commitment.lurk
@@ -21,7 +21,7 @@
 
 ;; We can verify the proof.
 
-!(verify "625c4982a35e7944defda517f91c3d19c30066a9dba6ab551b38dd6f9d734d")
+!(verify "8930a611d0dcc7af859ea47e9c36cc418f8bbf039333e44325cb1d1e7fdbd4")
 
 ;; Now let's chain another call to the new head, adding 12 to the counter.
 
@@ -35,7 +35,7 @@
 
 ;; And verify.
 
-!(verify "4aba13454094a0aa3eb99300b2987313b3de1b002bfef91b4979b2a0b023d0")
+!(verify "59bb86e6b8c460ef3742629c876fbeadea0ddcbb8bc6a5fdaec86dfc1c5dfb")
 
 ;; One more time, we'll add 14 to the head commitment's internal state.
 
@@ -49,7 +49,7 @@
 
 ;; Verify.
 
-!(verify "34ea707e0f593f8d8639b5bd85fdc57584fea433b216e43cfa078f28649333")
+!(verify "7a36cc7454fbf3b0880b798eb21dcad540ab028a63ac45ebaac7c0a3198c80")
 
 ;; Repeat indefinitely.
 

--- a/demo/functional-commitment.lurk
+++ b/demo/functional-commitment.lurk
@@ -18,8 +18,8 @@
 
 ;; We can inspect the input/output expressions of the proof.
 
-!(inspect "6f55589cdb2158ad4a35860d288eccc7bb392eaab7bc703bcefb9f8ca2b9b2")
+!(inspect "5862775241522ce16db294dded18d925dec61de5a43d7f3dd04c533e779935")
 
 ;; Finally, and most importantly, we can verify the proof.
 
-!(verify "6f55589cdb2158ad4a35860d288eccc7bb392eaab7bc703bcefb9f8ca2b9b2")
+!(verify "5862775241522ce16db294dded18d925dec61de5a43d7f3dd04c533e779935")

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -312,6 +312,11 @@ test!(
 test!(test_secret, "(secret (commit 123))", |_| ZPtr::comm(
     [F::zero(); 8]
 ));
+test!(
+    test_func_comm_app,
+    "(begin (commit (lambda (x) x)) (#0x3f2e7102a9f8a303255b90724f24f4eb05b61e99723ca838cf30671676c86a 42))",
+    |_| uint(42)
+);
 
 // errors
 test!(test_unbound_var, "a", |_| ZPtr::err(EvalErr::UnboundVar));


### PR DESCRIPTION
Make the `chain`, `call` and `transition` meta commands accept an arbitrary number of arguments.

Extra: make commitments viable callable objects as they might be functional commitments.

Closes #216