### PR TITLE
feat: `erase-from-env` meta command

### DIFF
--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -278,7 +278,7 @@ pub(crate) const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
     ">=",
 ];
 
-const META_PACKAGE_SYMBOLS_NAMES: [&str; 27] = [
+const META_PACKAGE_SYMBOLS_NAMES: [&str; 29] = [
     "def",
     "defrec",
     "load",
@@ -292,6 +292,7 @@ const META_PACKAGE_SYMBOLS_NAMES: [&str; 27] = [
     "open",
     "clear",
     "set-env",
+    "erase-from-env",
     "prove",
     "verify",
     "defpackage",
@@ -300,6 +301,7 @@ const META_PACKAGE_SYMBOLS_NAMES: [&str; 27] = [
     "help",
     "call",
     "chain",
+    "transition",
     "inspect",
     "dump-expr",
     "load-expr",

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -827,7 +827,7 @@ impl<F: Field, H: Chipset<F>> ZStore<F, H> {
         }
     }
 
-    fn fetch_env<'a>(&'a self, mut zptr: &'a ZPtr<F>) -> Vec<(&ZPtr<F>, &ZPtr<F>)>
+    pub fn fetch_env<'a>(&'a self, mut zptr: &'a ZPtr<F>) -> Vec<(&ZPtr<F>, &ZPtr<F>)>
     where
         F: PrimeField32,
     {


### PR DESCRIPTION
Factoring out important code from #229.

Extra: a few fixes when printing errors