### PR TITLE
chore: make REPL not panic when openings can't be done

### DIFF
--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -76,7 +76,9 @@ fn evaluation(c: &mut Criterion) {
         b.iter_batched(
             || (args.clone(), record.clone()),
             |(args, mut queries)| {
-                toplevel.execute(lurk_main.func(), &args, &mut queries);
+                toplevel
+                    .execute(lurk_main.func(), &args, &mut queries)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -88,7 +90,9 @@ fn trace_generation(c: &mut Criterion) {
     c.bench_function(&format!("trace-generation-{arg}"), |b| {
         let (toplevel, _) = build_lurk_toplevel();
         let (args, lurk_main, mut record) = setup(arg, &toplevel);
-        toplevel.execute(lurk_main.func(), &args, &mut record);
+        toplevel
+            .execute(lurk_main.func(), &args, &mut record)
+            .unwrap();
         let lair_chips = build_lair_chip_vector(&lurk_main);
         b.iter(|| {
             lair_chips.par_iter().for_each(|func_chip| {
@@ -108,7 +112,9 @@ fn e2e(c: &mut Criterion) {
         b.iter_batched(
             || (record.clone(), args.clone()),
             |(mut record, args)| {
-                toplevel.execute(lurk_main.func(), &args, &mut record);
+                toplevel
+                    .execute(lurk_main.func(), &args, &mut record)
+                    .unwrap();
                 let config = BabyBearPoseidon2::new();
                 let machine = StarkMachine::new(
                     config,

--- a/benches/lcs.rs
+++ b/benches/lcs.rs
@@ -80,7 +80,9 @@ fn evaluation(c: &mut Criterion) {
         b.iter_batched(
             || (args.clone(), record.clone()),
             |(args, mut queries)| {
-                toplevel.execute(lurk_main.func(), &args, &mut queries);
+                toplevel
+                    .execute(lurk_main.func(), &args, &mut queries)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -92,7 +94,9 @@ fn trace_generation(c: &mut Criterion) {
     c.bench_function("trace-generation", |b| {
         let (toplevel, _) = build_lurk_toplevel();
         let (args, lurk_main, mut record) = setup(args.0, args.1, &toplevel);
-        toplevel.execute(lurk_main.func(), &args, &mut record);
+        toplevel
+            .execute(lurk_main.func(), &args, &mut record)
+            .unwrap();
         let lair_chips = build_lair_chip_vector(&lurk_main);
         b.iter(|| {
             lair_chips.par_iter().for_each(|func_chip| {
@@ -112,7 +116,9 @@ fn e2e(c: &mut Criterion) {
         b.iter_batched(
             || (record.clone(), args.clone()),
             |(mut record, args)| {
-                toplevel.execute(lurk_main.func(), &args, &mut record);
+                toplevel
+                    .execute(lurk_main.func(), &args, &mut record)
+                    .unwrap();
                 let config = BabyBearPoseidon2::new();
                 let machine = StarkMachine::new(
                     config,

--- a/benches/sum.rs
+++ b/benches/sum.rs
@@ -83,7 +83,9 @@ fn evaluation(c: &mut Criterion) {
         b.iter_batched(
             || (args.clone(), record.clone()),
             |(args, mut queries)| {
-                toplevel.execute(lurk_main.func(), &args, &mut queries);
+                toplevel
+                    .execute(lurk_main.func(), &args, &mut queries)
+                    .unwrap();
             },
             BatchSize::SmallInput,
         )
@@ -95,7 +97,9 @@ fn trace_generation(c: &mut Criterion) {
     c.bench_function("trace-generation", |b| {
         let (toplevel, _) = build_lurk_toplevel();
         let (args, lurk_main, mut record) = setup(arg, &toplevel);
-        toplevel.execute(lurk_main.func(), &args, &mut record);
+        toplevel
+            .execute(lurk_main.func(), &args, &mut record)
+            .unwrap();
         let lair_chips = build_lair_chip_vector(&lurk_main);
         b.iter(|| {
             lair_chips.par_iter().for_each(|func_chip| {
@@ -115,7 +119,9 @@ fn e2e(c: &mut Criterion) {
         b.iter_batched(
             || (record.clone(), args.clone()),
             |(mut record, args)| {
-                toplevel.execute(lurk_main.func(), &args, &mut record);
+                toplevel
+                    .execute(lurk_main.func(), &args, &mut record)
+                    .unwrap();
                 let config = BabyBearPoseidon2::new();
                 let machine = StarkMachine::new(
                     config,

--- a/src/lair/air.rs
+++ b/src/lair/air.rs
@@ -525,13 +525,17 @@ mod tests {
 
         let mut queries = QueryRecord::new(&toplevel);
         let factorial_chip = FuncChip::from_name("factorial", &toplevel);
-        toplevel.execute_by_name("factorial", &[F::from_canonical_usize(5)], &mut queries);
+        toplevel
+            .execute_by_name("factorial", &[F::from_canonical_usize(5)], &mut queries)
+            .unwrap();
         let factorial_trace = factorial_chip.generate_trace(&Shard::new(&queries));
         let _ = debug_constraints_collecting_queries(&factorial_chip, &[], None, &factorial_trace);
 
         let fib_chip = FuncChip::from_name("fib", &toplevel);
         let mut queries = QueryRecord::new(&toplevel);
-        toplevel.execute_by_name("fib", &[F::from_canonical_usize(7)], &mut queries);
+        toplevel
+            .execute_by_name("fib", &[F::from_canonical_usize(7)], &mut queries)
+            .unwrap();
         let fib_trace = fib_chip.generate_trace(&Shard::new(&queries));
         let _ = debug_constraints_collecting_queries(&fib_chip, &[], None, &fib_trace);
     }
@@ -542,7 +546,7 @@ mod tests {
         let fib_chip = FuncChip::from_name("fib", &toplevel);
         let args = &[field_from_u32(20000)];
         let mut queries = QueryRecord::new(&toplevel);
-        toplevel.execute_by_name("fib", args, &mut queries);
+        toplevel.execute_by_name("fib", args, &mut queries).unwrap();
         let fib_trace = fib_chip.generate_trace(&Shard::new(&queries));
 
         let _ = debug_constraints_collecting_queries(&fib_chip, &[], None, &fib_trace);
@@ -566,13 +570,13 @@ mod tests {
 
         let mut queries = QueryRecord::new(&toplevel);
         let args = &[field_from_u32(4)];
-        toplevel.execute_by_name("not", args, &mut queries);
+        toplevel.execute_by_name("not", args, &mut queries).unwrap();
         let args = &[field_from_u32(8)];
-        toplevel.execute_by_name("not", args, &mut queries);
+        toplevel.execute_by_name("not", args, &mut queries).unwrap();
         let args = &[field_from_u32(0)];
-        toplevel.execute_by_name("not", args, &mut queries);
+        toplevel.execute_by_name("not", args, &mut queries).unwrap();
         let args = &[field_from_u32(1)];
-        toplevel.execute_by_name("not", args, &mut queries);
+        toplevel.execute_by_name("not", args, &mut queries).unwrap();
         let not_trace = not_chip.generate_trace(&Shard::new(&queries));
 
         let not_width = not_chip.width();
@@ -593,13 +597,13 @@ mod tests {
 
         let mut queries = QueryRecord::new(&toplevel);
         let args = &[field_from_u32(4), field_from_u32(2)];
-        toplevel.execute_by_name("eq", args, &mut queries);
+        toplevel.execute_by_name("eq", args, &mut queries).unwrap();
         let args = &[field_from_u32(4), field_from_u32(4)];
-        toplevel.execute_by_name("eq", args, &mut queries);
+        toplevel.execute_by_name("eq", args, &mut queries).unwrap();
         let args = &[field_from_u32(0), field_from_u32(3)];
-        toplevel.execute_by_name("eq", args, &mut queries);
+        toplevel.execute_by_name("eq", args, &mut queries).unwrap();
         let args = &[field_from_u32(0), field_from_u32(0)];
-        toplevel.execute_by_name("eq", args, &mut queries);
+        toplevel.execute_by_name("eq", args, &mut queries).unwrap();
         let eq_trace = eq_chip.generate_trace(&Shard::new(&queries));
 
         let eq_width = eq_chip.width();
@@ -639,13 +643,21 @@ mod tests {
         let mut queries = QueryRecord::new(&toplevel);
         let f = field_from_u32;
         let args = &[f(0), f(0), f(0), f(0)];
-        toplevel.execute_by_name("if_many", args, &mut queries);
+        toplevel
+            .execute_by_name("if_many", args, &mut queries)
+            .unwrap();
         let args = &[f(1), f(3), f(8), f(2)];
-        toplevel.execute_by_name("if_many", args, &mut queries);
+        toplevel
+            .execute_by_name("if_many", args, &mut queries)
+            .unwrap();
         let args = &[f(0), f(0), f(4), f(1)];
-        toplevel.execute_by_name("if_many", args, &mut queries);
+        toplevel
+            .execute_by_name("if_many", args, &mut queries)
+            .unwrap();
         let args = &[f(0), f(0), f(0), f(9)];
-        toplevel.execute_by_name("if_many", args, &mut queries);
+        toplevel
+            .execute_by_name("if_many", args, &mut queries)
+            .unwrap();
 
         let if_many_trace = if_many_chip.generate_trace(&Shard::new(&queries));
 
@@ -700,15 +712,25 @@ mod tests {
         let mut queries = QueryRecord::new(&toplevel);
         let f = field_from_u32;
         let args = &[f(0), f(0)];
-        toplevel.execute_by_name("match_many", args, &mut queries);
+        toplevel
+            .execute_by_name("match_many", args, &mut queries)
+            .unwrap();
         let args = &[f(0), f(1)];
-        toplevel.execute_by_name("match_many", args, &mut queries);
+        toplevel
+            .execute_by_name("match_many", args, &mut queries)
+            .unwrap();
         let args = &[f(1), f(0)];
-        toplevel.execute_by_name("match_many", args, &mut queries);
+        toplevel
+            .execute_by_name("match_many", args, &mut queries)
+            .unwrap();
         let args = &[f(1), f(1)];
-        toplevel.execute_by_name("match_many", args, &mut queries);
+        toplevel
+            .execute_by_name("match_many", args, &mut queries)
+            .unwrap();
         let args = &[f(0), f(8)];
-        toplevel.execute_by_name("match_many", args, &mut queries);
+        toplevel
+            .execute_by_name("match_many", args, &mut queries)
+            .unwrap();
 
         let match_many_trace = match_many_chip.generate_trace(&Shard::new(&queries));
 
@@ -755,7 +777,9 @@ mod tests {
         let mut queries = QueryRecord::new(&toplevel);
         let f = field_from_u32;
         let args = &[f(2), f(4), f(6), f(8)];
-        toplevel.execute_by_name("assert", args, &mut queries);
+        toplevel
+            .execute_by_name("assert", args, &mut queries)
+            .unwrap();
         let chip = FuncChip::from_name("assert", &toplevel);
         let trace = chip.generate_trace(&Shard::new(&queries));
 
@@ -790,13 +814,21 @@ mod tests {
         let mut queries = QueryRecord::new(&toplevel);
         let f = field_from_u32;
         let args = &[f(1)];
-        toplevel.execute_by_name("test", args, &mut queries);
+        toplevel
+            .execute_by_name("test", args, &mut queries)
+            .unwrap();
         let args = &[f(2)];
-        toplevel.execute_by_name("test", args, &mut queries);
+        toplevel
+            .execute_by_name("test", args, &mut queries)
+            .unwrap();
         let args = &[f(3)];
-        toplevel.execute_by_name("test", args, &mut queries);
+        toplevel
+            .execute_by_name("test", args, &mut queries)
+            .unwrap();
         let args = &[f(4)];
-        toplevel.execute_by_name("test", args, &mut queries);
+        toplevel
+            .execute_by_name("test", args, &mut queries)
+            .unwrap();
         let chip = FuncChip::from_name("test", &toplevel);
         let trace = chip.generate_trace(&Shard::new(&queries));
 
@@ -834,7 +866,9 @@ mod tests {
 
         let f = F::from_canonical_usize;
         let args = &[f(100), f(12), f(64)];
-        toplevel.execute_by_name("range_test", args, &mut queries);
+        toplevel
+            .execute_by_name("range_test", args, &mut queries)
+            .unwrap();
         let trace = range_chip.generate_trace(&Shard::new(&queries));
         #[rustfmt::skip]
         let expected_trace = [

--- a/src/lair/lair_chip.rs
+++ b/src/lair/lair_chip.rs
@@ -241,7 +241,9 @@ mod tests {
         let chip = FuncChip::from_name("factorial", &toplevel);
         let mut queries = QueryRecord::new(&toplevel);
 
-        toplevel.execute_by_name("factorial", &[F::from_canonical_u8(5)], &mut queries);
+        toplevel
+            .execute_by_name("factorial", &[F::from_canonical_u8(5)], &mut queries)
+            .unwrap();
 
         let config = BabyBearPoseidon2::new();
         let machine = StarkMachine::new(

--- a/src/lair/memory.rs
+++ b/src/lair/memory.rs
@@ -142,7 +142,7 @@ mod tests {
         let toplevel = Toplevel::<F, Nochip>::new_pure(&[func_e]);
         let test_chip = FuncChip::from_name("test", &toplevel);
         let mut queries = QueryRecord::new(&toplevel);
-        toplevel.execute_by_name("test", &[], &mut queries);
+        toplevel.execute_by_name("test", &[], &mut queries).unwrap();
         let func_trace = test_chip.generate_trace(&Shard::new(&queries));
 
         #[rustfmt::skip]

--- a/src/lair/trace.rs
+++ b/src/lair/trace.rs
@@ -403,7 +403,9 @@ mod tests {
         let mut queries = QueryRecord::new(&toplevel);
 
         let args = &[F::from_canonical_u32(5)];
-        toplevel.execute_by_name("factorial", args, &mut queries);
+        toplevel
+            .execute_by_name("factorial", args, &mut queries)
+            .unwrap();
         let trace = factorial_chip.generate_trace(&Shard::new(&queries));
         #[rustfmt::skip]
         let expected_trace = [
@@ -425,7 +427,7 @@ mod tests {
 
         let mut queries = QueryRecord::new(&toplevel);
         let args = &[F::from_canonical_u32(7)];
-        toplevel.execute_by_name("fib", args, &mut queries);
+        toplevel.execute_by_name("fib", args, &mut queries).unwrap();
         let trace = fib_chip.generate_trace(&Shard::new(&queries));
 
         #[rustfmt::skip]
@@ -486,7 +488,9 @@ mod tests {
 
         let args = &[F::from_canonical_u32(5), F::from_canonical_u32(2)];
         let mut queries = QueryRecord::new(&toplevel);
-        toplevel.execute_by_name("test", args, &mut queries);
+        toplevel
+            .execute_by_name("test", args, &mut queries)
+            .unwrap();
         let trace = test_chip.generate_trace(&Shard::new(&queries));
         #[rustfmt::skip]
         let expected_trace = [
@@ -555,10 +559,10 @@ mod tests {
         let three = &[F::from_canonical_u32(1), F::from_canonical_u32(1)];
         let mut queries = QueryRecord::new(&toplevel);
         let test_func = toplevel.get_by_name("test");
-        toplevel.execute(test_func, zero, &mut queries);
-        toplevel.execute(test_func, one, &mut queries);
-        toplevel.execute(test_func, two, &mut queries);
-        toplevel.execute(test_func, three, &mut queries);
+        toplevel.execute(test_func, zero, &mut queries).unwrap();
+        toplevel.execute(test_func, one, &mut queries).unwrap();
+        toplevel.execute(test_func, two, &mut queries).unwrap();
+        toplevel.execute(test_func, three, &mut queries).unwrap();
         let trace = test_chip.generate_trace(&Shard::new(&queries));
 
         let expected_trace = [
@@ -608,7 +612,9 @@ mod tests {
         // These inputs should perform enough recursive calls (5242889) to
         // generate 2 shards with the default shard size of 1 << 22
         let inp = &[f(3), f(18)];
-        let out = toplevel.execute_by_name("ackermann", inp, &mut queries);
+        let out = toplevel
+            .execute_by_name("ackermann", inp, &mut queries)
+            .unwrap();
         // For constant m = 3, A(3, n) = 2^(n + 3) - 3
         assert_eq!(out[0], f(2097149));
 

--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -1673,11 +1673,13 @@ mod test {
             ingress_args[0] = tag;
             ingress_args[8..].copy_from_slice(&digest);
 
-            toplevel.execute(ingress, &ingress_args, &mut queries);
+            toplevel
+                .execute(ingress, &ingress_args, &mut queries)
+                .unwrap();
             let ingress_out_ptr = queries.get_output(ingress, &ingress_args)[0];
 
             let egress_args = &[tag, ingress_out_ptr];
-            toplevel.execute(egress, egress_args, &mut queries);
+            toplevel.execute(egress, egress_args, &mut queries).unwrap();
             let egress_out = queries.get_output(egress, egress_args);
 
             assert_eq!(

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -61,7 +61,9 @@ fn run_test(
     input[16..].copy_from_slice(&env.digest);
 
     let lurk_main = FuncChip::from_name("lurk_main", toplevel);
-    let result = toplevel.execute(lurk_main.func, &input, &mut record);
+    let result = toplevel
+        .execute(lurk_main.func, &input, &mut record)
+        .unwrap();
 
     assert_eq!(result.as_ref(), &expected_cloj(zstore).flatten());
 

--- a/src/lurk/syntax.rs
+++ b/src/lurk/syntax.rs
@@ -48,9 +48,9 @@ impl<F> Syntax<F> {
 }
 
 /// Returns a `BigUint` from a digest of field elements stored in little-endian order.
-pub fn digest_to_biguint<F: PrimeField>(digest: &[F; DIGEST_SIZE]) -> BigUint {
-    let mut num = digest[DIGEST_SIZE - 1].as_canonical_biguint();
-    for l in digest[..DIGEST_SIZE - 1].iter().rev() {
+pub fn digest_to_biguint<F: PrimeField>(digest: &[F]) -> BigUint {
+    let mut num = digest[digest.len() - 1].as_canonical_biguint();
+    for l in digest[..digest.len() - 1].iter().rev() {
         num *= F::order();
         num += l.as_canonical_biguint();
     }

--- a/src/lurk/u64.rs
+++ b/src/lurk/u64.rs
@@ -274,7 +274,7 @@ mod test {
             f(0),
             f(0),
         ];
-        let out = toplevel.execute_by_name("add", args, &mut queries);
+        let out = toplevel.execute_by_name("add", args, &mut queries).unwrap();
         assert_eq!(
             out.as_ref(),
             &[f(0), f(1), f(0), f(0), f(0), f(0), f(0), f(0)]
@@ -330,7 +330,7 @@ mod test {
             f(0),
             f(0),
         ];
-        let out = toplevel.execute_by_name("sub", args, &mut queries);
+        let out = toplevel.execute_by_name("sub", args, &mut queries).unwrap();
         assert_eq!(
             out.as_ref(),
             &[f(255), f(0), f(0), f(0), f(0), f(0), f(0), f(0)]
@@ -390,7 +390,7 @@ mod test {
             f(0),
             f(0),
         ];
-        let out = toplevel.execute_by_name("mul", args, &mut queries);
+        let out = toplevel.execute_by_name("mul", args, &mut queries).unwrap();
         assert_eq!(
             out.as_ref(),
             &[f(0), f(0), f(0), f(0), f(1), f(0), f(0), f(0)]
@@ -446,7 +446,9 @@ mod test {
             f(0),
             f(0),
         ];
-        let out = toplevel.execute_by_name("divrem", args, &mut queries);
+        let out = toplevel
+            .execute_by_name("divrem", args, &mut queries)
+            .unwrap();
         assert_eq!(
             out.as_ref(),
             &[
@@ -520,7 +522,9 @@ mod test {
             f(0),
             f(0),
         ];
-        let out = toplevel.execute_by_name("lessthan", args, &mut queries);
+        let out = toplevel
+            .execute_by_name("lessthan", args, &mut queries)
+            .unwrap();
         assert_eq!(out.as_ref(), &[f(1)]);
 
         let lair_chips = build_lair_chip_vector(&lessthan_chip);
@@ -555,7 +559,9 @@ mod test {
         let f = F::from_canonical_usize;
         // Little endian
         let args = &[f(0), f(0), f(0), f(0), f(0), f(0), f(0), f(0)];
-        let out = toplevel.execute_by_name("iszero", args, &mut queries);
+        let out = toplevel
+            .execute_by_name("iszero", args, &mut queries)
+            .unwrap();
         assert_eq!(out.as_ref(), &[f(1)]);
 
         let lair_chips = build_lair_chip_vector(&iszero_chip);
@@ -574,7 +580,9 @@ mod test {
 
         let mut queries = QueryRecord::new(&toplevel);
         let args = &[f(0), f(0), f(0), f(123), f(0), f(0), f(0), f(0)];
-        let out = toplevel.execute_by_name("iszero", args, &mut queries);
+        let out = toplevel
+            .execute_by_name("iszero", args, &mut queries)
+            .unwrap();
         assert_eq!(out.as_ref(), &[f(0)]);
 
         let lair_chips = build_lair_chip_vector(&iszero_chip);

--- a/src/lurk/zstore.rs
+++ b/src/lurk/zstore.rs
@@ -998,7 +998,9 @@ mod test {
         input[0] = expr_tag.to_field();
         input[8..16].copy_from_slice(&expr_digest);
 
-        let output = toplevel.execute_by_name("lurk_main", &input, record);
+        let output = toplevel
+            .execute_by_name("lurk_main", &input, record)
+            .unwrap();
 
         let output_tag = Tag::from_field(&output[0]);
         let output_digest = &output[8..];

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -78,7 +78,9 @@ fn fib_e2e() {
     let (args, lurk_main, mut record) = setup(arg, &toplevel);
     let start_time = Instant::now();
 
-    toplevel.execute(lurk_main.func(), &args, &mut record);
+    toplevel
+        .execute(lurk_main.func(), &args, &mut record)
+        .unwrap();
     let config = BabyBearPoseidon2::new();
     let machine = StarkMachine::new(
         config,


### PR DESCRIPTION
Lair's execution algorithm now returns `Result<List<F>>` so we can bail when things go wrong and we want to upstream an error message.

Closes #226