### PR TITLE
chore: Update CI token

### DIFF
--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -27,12 +27,18 @@ jobs:
         if: steps.compare-versions.outputs.outdated == 'true'
         run: |
           sed -i 's/channel = .*/channel = "nightly-${{ env.RUST_VERSION }}"/' rust-toolchain.toml
+      - uses: tibdex/github-app-token@v2
+        if: steps.compare-versions.outputs.outdated == 'true'
+        id: generate-token
+        with:
+          app_id: ${{ secrets.TOKEN_APP_ID }}
+          private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
       # Open PR if Rust version is out of date with latest nightly
       - name: Create Pull Request
         if: steps.compare-versions.outputs.outdated == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: "${{ secrets.REPO_TOKEN }}"
+          token: ${{ steps.generate-token.outputs.token }}
           branch: "ci-update-rust-version"
           title: "chore: Update Rust version to nightly-${{ env.RUST_VERSION }}"
           commit-message: "chore: Update Rust version to nightly-${{ env.RUST_VERSION }}"


### PR DESCRIPTION
Switches to a GH app token per https://github.com/argumentcomputer/zk-light-clients/pull/170