### PR TITLE
fix: `eval` behavior

### DIFF
--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -660,14 +660,15 @@ pub fn eval<F: AbstractField + Ord>(builtins: &BuiltinMemo<'_, F>) -> FuncE<F> {
                                     let (expr_tag, expr, rest_tag, rest) = load(rest);
                                     match rest_tag {
                                         Tag::Nil => {
-                                            let env = 0;
-                                            // Eval must be called twice
+                                            // Eval must be called twice, first with the original env and then
+                                            // with an empty env
                                             let (res_tag, res) = call(eval, expr_tag, expr, env);
                                             match res_tag {
                                                 Tag::Err => {
                                                     return (res_tag, res)
                                                 }
                                             };
+                                            let env = 0;
                                             let (res_tag, res) = call(eval, res_tag, res, env);
                                             return (res_tag, res)
                                         }

--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -232,6 +232,7 @@ test!(test_eval, "(eval '(+ 1 2) (empty-env))", |_| uint(3));
 test!(test_eval2, "(eval 'x (let ((x 1)) (current-env)))", |_| {
     uint(1)
 });
+test!(test_eval3, "(let ((a '(+ 1 1))) (eval a))", |_| uint(2));
 test!(test_cons, "(cons 0n 1n)", |z| {
     z.intern_cons(ZPtr::num(F::zero()), ZPtr::num(F::one()))
 });


### PR DESCRIPTION
First evaluation of `eval`'s argument should use the original env.

Closes #242