### PR TITLE
feat: finish type coersions

### DIFF
--- a/src/lurk/eval_tests.rs
+++ b/src/lurk/eval_tests.rs
@@ -256,6 +256,12 @@ test!(test_type_eqq1, "(type-eqq (nil) (cons 1 2))", |z| z
     .intern_symbol(&lurk_sym("t")));
 test!(test_type_eqq2, "(type-eqq 2 'a')", |z| z.intern_nil());
 
+// coercions
+test!(test_char1, "(char 'a')", |z| z.intern_char('a'));
+test!(test_char2, "(char 97)", |z| z.intern_char('a'));
+test!(test_u64_1, "(u64 97)", |_| uint(97));
+test!(test_u64_2, "(u64 'a')", |_| uint(97));
+
 // environment
 test!(
     test_current_env,

--- a/src/lurk/state.rs
+++ b/src/lurk/state.rs
@@ -239,13 +239,12 @@ const LURK_PACKAGE_SYMBOL_NAME: &str = "lurk";
 const USER_PACKAGE_SYMBOL_NAME: &str = "user";
 const META_PACKAGE_SYMBOL_NAME: &str = "meta";
 
-pub(crate) const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 38] = [
+pub(crate) const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 36] = [
     "atom",
     "begin",
     "car",
     "cdr",
     "char",
-    "comm",
     "commit",
     "cons",
     "current-env",
@@ -261,7 +260,6 @@ pub(crate) const LURK_PACKAGE_SYMBOLS_NAMES: [&str; 38] = [
     "let",
     "letrec",
     "nil",
-    "num",
     "u64",
     "open",
     "quote",


### PR DESCRIPTION
* Drop field dependent builtins `comm` and `num`
* Implement a stable coersions between `u64` and `char`