### PR TITLE
chore: forbid ingressing errors

### DIFF
--- a/src/lurk/eval.rs
+++ b/src/lurk/eval.rs
@@ -166,7 +166,7 @@ pub fn ingress<F: AbstractField + Ord>() -> FuncE<F> {
             let (tag, rest: [7]) = tag_full;
             assert_eq!(rest, zeros);
             match tag {
-                Tag::Num, Tag::Err => {
+                Tag::Num => {
                     let (x, rest: [7]) = digest;
                     assert_eq!(rest, zeros);
                     return x


### PR DESCRIPTION
Since we have eager ingression in place, this solution prevents errors from being part of the reduction input.