### PR TITLE
Add lib with initial struct.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 repository.workspace = true
 
-# [[bin]]
-# name = "lurk"
-# path = "src/main.rs"
+[[bin]]
+name = "lurk"
+path = "src/main.rs"
 
 [workspace.package]
 authors = ["Argument Engineering <engineering@argument.xyz>"]

--- a/lib/struct-test.lurk
+++ b/lib/struct-test.lurk
@@ -1,5 +1,7 @@
 !(load "struct.lurk")
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; struct
 !(def foo (struct '(:a :b :c)))
 !(def x ((foo :new) '(1 2 3)))
 
@@ -8,8 +10,7 @@
 !(assert-eq 3 (x :c))
 
 !(def y ((foo :new) '(9 8 7)))
-!(def foo-b (lambda (x) (nth 2 (cdr x))))
-
+(emit (cons :foo-new ((foo :new) '(9 8 7)))) ;; 14 iterations
 
 ;; First access of :b in x -- 55 iterations
 (cons :xb (x :b))
@@ -30,4 +31,37 @@
 ;; First access of :a in y -- 14 iterations
 (cons :xb-yb-xa-ya (begin (x :b) (y :b) (x :a) (y :a)))
 ;; [127 iterations] => (:xb-yb-xa-ya . 9)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; alist-struct
+
+!(def foo (alist-struct '(:a :b :c)))
+!(def x ((foo :new) '(1 2 3)))
+
+!(assert-eq 1 (x :a))
+!(assert-eq 2 (x :b))
+!(assert-eq 3 (x :c))
+
+!(def y ((foo :new) '(9 8 7)))
+(emit (cons :foo-new ((foo :new) '(9 8 7)))) ;; 64 iterations
+
+;; First access of :b in x -- 32 iterations
+(cons :xb (x :b))
+;; [32 iterations] => (:xb . 2)
+
+;; Second access of :b in x -- 1 iteration
+(cons :xb-xb (begin (x :b) (x :b)))
+;; [34 iterations] => (:xb-xb . 2)
+
+;; First access of :b in y -- 30 iterations
+(cons :xb-xy (begin (x :b) (y :b)))
+;; [63 iterations] => (:xb-xy . 8)
+
+;; First access of :a in x -- 20 iterations
+(cons :xb-yb-xa (begin (x :b) (y :b) (x :a)))
+;; [113 iterations] => (:xb-yb-xa . 1)
+
+;; First access of :a in y -- 19 iterations
+(cons :xb-yb-xa-ya (begin (x :b) (y :b) (x :a) (y :a)))
+;; [102 iterations] => (:xb-yb-xa-ya . 9)
 

--- a/lib/struct.lurk
+++ b/lib/struct.lurk
@@ -2,6 +2,17 @@
 !(load "util.lurk")
 
 ;; Crude first-draft of struct implementation.
+!(def alist-struct (lambda (fields)
+               (lambda (op)
+                 ;; Both :new and :type are a bit silly and could be normal functions.
+                 ;; However this allows an interface that abstracts the implementation.
+                 (if (eq op :new)
+                     (lambda (vals)
+                     (let ((alist (emit (zip fields vals))))
+                       (lambda (field)
+                         (cdr (assoc field alist)))))))))
+
+;; Crude first-draft of struct implementation.
 !(def struct (lambda (args)
                (lambda (op)
                  ;; Both :new and :type are a bit silly and could be normal functions.

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -9,3 +9,28 @@
 
 ;; apply
 !(assert-eq 27 (apply (lambda (x y z) (* x (+ y z))) '(3 4 5)))
+
+;; getf
+!(assert-eq 2 (getf '(:a 1 :b 2 :c 3) :b))
+(emit (cons :getf-2 (getf '(:a 1 :b 2 :c 3) :b))) ; 30 iterations
+
+!(assert-eq nil (getf '(:a 1 :b 2 :c 3) :d))
+
+;; assoc
+!(assert-eq '(:b . 2) (assoc :b '((:a . 1) (:b . 2) (:c . 3))))
+(emit (cons :assoc-b (assoc :b '((:a . 1) (:b . 2) (:c . 3))))) ;; 29 iterations
+
+!(assert-eq nil (assoc :d '((:a . 1) (:b . 2) (:c . 3))))
+(emit (cons :assoc-d (assoc :d '((:a . 1) (:b . 2) (:c . 3))))) ; 44 iterations
+
+!(assert-eq nil (assoc :d '((:a . 1) (:b . 2) (:c . 3))))
+
+;; length
+!(assert-eq 3 (length '(a b c)))
+!(assert-eq 0 (length ()))
+
+;; reverse
+!(assert-eq '(c b a) (reverse '(a b c)))
+
+;; zip
+!(assert-eq '((a . 1) (b . 2) (c . 3)) (zip '(a b c) '(1 2 3)))

--- a/lib/util.lurk
+++ b/lib/util.lurk
@@ -25,3 +25,36 @@
                          (apply (f (car args)) (cdr args))
                          (f (car args)))
                      (f))))
+
+!(def getf (lambda (plist indicator)
+             (letrec ((aux (lambda (plist)
+                             (if plist
+                                 (if (eq (car plist) indicator)
+                                     (car (cdr plist))
+                                     (aux (cdr (cdr plist))))))))
+               (aux plist))))
+
+!(def assoc (lambda (item alist)
+              (letrec ((aux (lambda (alist)
+                              (if alist
+                                  (if (eq (car (car alist)) item)
+                                      (car alist)
+                                      (aux (cdr alist)))))))
+                (aux alist))))
+
+!(defrec length (lambda (l) (if l (+ 1 (length (cdr l))) 0)))
+
+!(defrec reverse
+        (lambda (l)
+          (letrec ((aux (lambda (acc l)
+                          (if l
+                              (aux (cons (car l) acc) (cdr l))
+                              acc))))
+            (aux nil l))))
+
+!(def zip (lambda (a b)
+            (letrec ((aux (lambda (a b)
+                            (if a
+                                (if b
+                                    (cons (cons (car a) (car b)) (aux (cdr a) (cdr b))))))))
+              (aux a b))))


### PR DESCRIPTION
This PR adds a first cut at what might become a standard library. I've been writing a good amount of load-bearing code, working on demos and prototypes. I've reached the point that having more structure, and more reusable tools will be helpful. This will grow, change, etc. over time.

The original point of this can be seen in `struct.lurk` — which implements an idea for structs with named fields. The idea is to come up with an interface that is relatively legible and will benefit from memoization. See the iteration counts in `struct-test.lurk` to see how it worked out. There is room for improvement and increased functionality, of course, but the basic idea seems to hold up.

Importantly:
- repeated access to the same field of the same struct is very cheap (expected with memoization).
- repeated access to the same field of a different struct (same type) is cheaper than first access.
- repeated access of different fields in same structs is cheaper than first access to that field would have been

We try to manage naming through function calls so that expensive resolutions are performed as few times as possible. This approach can probably be improved a lot, but I propose the general pattern as one worth thinking about and building on in library functions generally.

I will likely iterate on this design and on the expressiveness of the structs, while also trying to make use of them to simplify writing more sophisticated code. This may also help build a corpus of usage we can use to help understand design patterns. Once we understand usage better, we may be able to provide low-level support to improve performance across the board.

TODO:
- [ ] run the tests in `/lib/tests.lurk` as part of the test suite.
