### PR TITLE
fix: Read multiple forms at once in the REPL

### DIFF
--- a/src/lurk/cli/repl.rs
+++ b/src/lurk/cli/repl.rs
@@ -608,11 +608,9 @@ impl<F: PrimeField32, H: Chipset<F>> Repl<F, H> {
                                     if let Err(e) = self.handle_meta(&zptr, &self.pwd_path.clone())
                                     {
                                         eprintln!("!Error: {e}");
-                                        break;
                                     }
                                 } else if let Err(e) = self.handle_non_meta(&zptr) {
                                     eprintln!("Error: {e}");
-                                    break;
                                 }
                                 line = rest.to_string();
                             }


### PR DESCRIPTION
Fixes #221

The REPL now runs multiple forms when possible (i.e. space-separated forms. This can happen when pasting multiple lines into the REPL). Meta-commands like `!(prove)` or `!(debug)` still only refer to the last form executed.

In action:
```
user> 1 2 3
[1 iteration] => 1
[1 iteration] => 2
[1 iteration] => 3
user> (+ 1 2) (+ 3 4)
[3 iterations] => 3
[3 iterations] => 7
user> !(prove)
Proof key: "4d6f7e3e819de4ad6d85dc3b2215dfc9e5d8346eb182e91fb04b9084dd3b26"
user> !(inspect "4d6f7e3e819de4ad6d85dc3b2215dfc9e5d8346eb182e91fb04b9084dd3b26")
Expr: (+ 3 4)
Env: <Env ()>
Result: 7
user> (+ 1 2) (+
3 4)
[3 iterations] => 3
[3 iterations] => 7
user> (/ 1 0) (+ 1 2)
[3 iterations] => <Err DivByZero>
[3 iterations] => 3
user> ((lambda (x) (begin (emit "test") (x x))) (lambda (x) (begin (emit "test") (x x)))) (+ 1 2)
"test"
Error: Loop detected
[3 iterations] => 3
user> !(verify "nonexistent proof") (+ 1 2)
!Error: Proof not found
[3 iterations] => 3
```

"Read errors" will still short-circuit execution of additional forms:
```
user> (+ 1 -1) (+ 3 4)
Read error: Syntax error: Transient error: Signed integers are not yet supported. Using `(- 0 x)` instead of `-x` might work as a temporary workaround.
user> (+ 1 2]) (+ 3 4)


Read error: Syntax error: Parsing Error: ParseError { input: LocatedSpan { offset: 6, line: 1, fragment: "]) (+ 3 4)\n\n", extra: () }, expected: None, errors: [Nom(Tag)] }
```
This is harder to support because the error does not have the `rest` information necessary to try to continue parsing, and some read/parse errors are non-recoverable. The only unfortunate thing is how it interacts with negative ints (due to how they're being parsed currently), otherwise there is not much else to do in this case.