### PR TITLE
feat: Add curly brace syntax for env read/eval/print

### DIFF
--- a/src/core/eval_direct.rs
+++ b/src/core/eval_direct.rs
@@ -2068,7 +2068,7 @@ mod test {
         expect_eq(lurk_main.width(), expect!["97"]);
         expect_eq(preallocate_symbols.width(), expect!["188"]);
         expect_eq(eval_coroutine_expr.width(), expect!["10"]);
-        expect_eq(eval.width(), expect!["78"]);
+        expect_eq(eval.width(), expect!["79"]);
         expect_eq(eval_builtin_expr.width(), expect!["148"]);
         expect_eq(eval_bind_builtin.width(), expect!["110"]);
         expect_eq(eval_env_builtin.width(), expect!["81"]);

--- a/src/core/eval_direct.rs
+++ b/src/core/eval_direct.rs
@@ -29,7 +29,7 @@ use super::{
 fn native_lurk_funcs<F: PrimeField32>(
     digests: &SymbolsDigests<F>,
     coroutines: &FxIndexMap<Symbol, Coroutine<F>>,
-) -> [FuncE<F>; 39] {
+) -> [FuncE<F>; 40] {
     [
         lurk_main(),
         preallocate_symbols(digests),
@@ -37,6 +37,7 @@ fn native_lurk_funcs<F: PrimeField32>(
         eval_builtin_expr(digests),
         eval_bind_builtin(),
         eval_env_builtin(),
+        eval_env_literal(),
         eval_apply_builtin(),
         eval_coroutine_expr(digests, coroutines),
         eval_opening_unop(digests),
@@ -432,6 +433,10 @@ pub fn eval<F: AbstractField>() -> FuncE<F> {
                     // IMPORTANT: at this point this operation cannot return an error
                     let (_tag, ext_env) = call(extend_env_with_mutuals, binds_tag, binds, binds, mutual_env);
                     let (res_tag, res) = call(eval, body_tag, body, ext_env);
+                    return (res_tag, res)
+                }
+                Tag::Env => {
+                    let (res_tag, res) = call(eval_env_literal, expr, env);
                     return (res_tag, res)
                 }
             };
@@ -874,6 +879,44 @@ pub fn eval_env_builtin<F: AbstractField>() -> FuncE<F> {
                 }
             };
             let err = EvalErr::InvalidForm;
+            return (err_tag, err)
+        }
+    )
+}
+
+pub fn eval_env_literal<F: AbstractField>() -> FuncE<F> {
+    func!(
+        partial fn eval_env_literal(env_literal, env): [2] {
+            let env_tag = Tag::Env;
+            let err_tag = Tag::Err;
+            let nil_env = 0;
+            if !env_literal {
+                return (env_tag, nil_env)
+            }
+            let (sym_tag, sym, val_tag, val, rest) = load(env_literal);
+            match sym_tag {
+                Tag::Sym, Tag::Builtin, Tag::Coroutine => {
+                    let (val_tag, val) = call(eval, val_tag, val, env);
+                    match val_tag {
+                        Tag::Err => {
+                            return (val_tag, val)
+                        }
+                    };
+                    let (tail_env_tag, tail_env) = call(eval_env_literal, rest, env);
+                    match tail_env_tag {
+                        Tag::Env => {
+                            let env = store(sym_tag, sym, val_tag, val, tail_env);
+                            return (env_tag, env)
+                        }
+                        Tag::Err => {
+                            return (tail_env_tag, tail_env)
+                        }
+                    };
+                    let err = EvalErr::InvalidForm;
+                    return (err_tag, err)
+                }
+            };
+            let err = EvalErr::IllegalBindingVar;
             return (err_tag, err)
         }
     )

--- a/src/core/syntax.rs
+++ b/src/core/syntax.rs
@@ -33,6 +33,8 @@ pub enum Syntax<F> {
     Improper(Pos, Vec<Syntax<F>>, Box<Syntax<F>>),
     /// A meta command: !(foo 1 'a')
     Meta(Pos, SymbolRef, Vec<Syntax<F>>),
+    /// An environment literal: { a: 1, b: "hello" }
+    Env(Pos, Vec<(SymbolRef, Syntax<F>)>),
 }
 
 impl<F> Syntax<F> {
@@ -50,7 +52,8 @@ impl<F> Syntax<F> {
             | Self::Quote(pos, _)
             | Self::List(pos, _)
             | Self::Improper(pos, ..)
-            | Self::Meta(pos, ..) => pos,
+            | Self::Meta(pos, ..)
+            | Self::Env(pos, ..) => pos,
         }
     }
 }
@@ -101,6 +104,17 @@ impl<F: fmt::Display + PrimeField> fmt::Display for Syntax<F> {
                     write!(f, " {x}")?;
                 }
                 write!(f, ")")
+            }
+            Self::Env(_, env) => {
+                let mut iter = env.iter().peekable();
+                write!(f, "{{ ")?;
+                while let Some((sym, val)) = iter.next() {
+                    match iter.peek() {
+                        Some(_) => write!(f, "{sym}: {val}, ")?,
+                        None => write!(f, "{sym}: {val}")?,
+                    }
+                }
+                write!(f, " }}")
             }
         }
     }

--- a/src/core/tests/eval_direct.rs
+++ b/src/core/tests/eval_direct.rs
@@ -367,6 +367,38 @@ test!(test_env_builtin3, "(env (list 'a 1 2))", |z| {
     let val = z.intern_list([one, two]);
     z.intern_env(a, val, empty_env)
 });
+test!(test_env_literal, "{ a: 1, b: 2 }", |z| {
+    let empty_env = z.intern_empty_env();
+    let b = z.intern_symbol_no_lang(&user_sym("b"));
+    let two = z.intern_u64(2);
+    let b_2 = z.intern_env(b, two, empty_env);
+    let a = z.intern_symbol_no_lang(&user_sym("a"));
+    let one = z.intern_u64(1);
+    z.intern_env(a, one, b_2)
+});
+test!(test_env_literal_empty, "{  }", |z| { z.intern_empty_env() });
+test!(test_env_literal_add, "{ a: (+ 1 0), b: 2 }", |z| {
+    let empty_env = z.intern_empty_env();
+    let b = z.intern_symbol_no_lang(&user_sym("b"));
+    let two = z.intern_u64(2);
+    let b_2 = z.intern_env(b, two, empty_env);
+    let a = z.intern_symbol_no_lang(&user_sym("a"));
+    let one = z.intern_u64(1);
+    z.intern_env(a, one, b_2)
+});
+test!(
+    test_eval_with_env_literal,
+    "(eval '(+ a 1) { a: 1 })",
+    |_| { uint(2) }
+);
+test!(
+    test_quote_env_literal,
+    "(eval 'a '{ a: (1 1), b: 2 })",
+    |z| { z.intern_list([uint(1), uint(1)]) }
+);
+test!(test_env_literal_err, "{ a: (1 1), b: 2 }", |_| {
+    ZPtr::err(EvalErr::ApplyNonFunc)
+});
 test!(
     test_bind_builtin,
     "(bind 'a (- 2 1) (current-env))",


### PR DESCRIPTION
Deals with #408, #409, and #410.

```
(base) ➜  lurk git:(whz/fix-env) ✗ cargo run 
   Compiling lurk v0.5.0 (/Users/hantingz/Work/lurklab/lurk)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.46s
     Running `target/debug/lurk`
commit: 2025-01-16 db1a1f1c2250f3b17ded488068eac4a1ffd1c2f5
Lurk REPL welcomes you.
lurk-user> {}
[1 iteration] => {  }
lurk-user> { a: 1 }
[2 iterations] => { a: 1 }
lurk-user> { a: 1, b: 2 }
[3 iterations] => { a: 1, b: 2 }
lurk-user> { a: (+ 1 3), b: 2 }
[5 iterations] => { a: 4, b: 2 }
lurk-user> '{ a: (+ 1 3), b: 2 }
[1 iteration] => { a: (+ 1 3), b: 2 }
lurk-user> (eval '(+ a 1) { a: 1 })
[7 iterations] => 2
lurk-user> (eval 'a '{ a: (1 1), b: 2 })
[4 iterations] => (1 1)
lurk-user> (let ((a 1)) (current-env))
[3 iterations] => { a: 1 }
lurk-user> 
```