### PR TITLE
Lurkscript

### DIFF
--- a/src/core/cli/meta.rs
+++ b/src/core/cli/meta.rs
@@ -1561,7 +1561,7 @@ mod test {
 
     #[test]
     fn test_def() {
-        let mut repl = Repl::new_native();
+        let mut repl = Repl::new_native(false);
         let foo = repl.zstore.intern_symbol_no_lang(&user_sym("foo"));
         let a = repl.zstore.intern_symbol_no_lang(&user_sym("a"));
         let args = repl.zstore.intern_list([foo, a]);

--- a/src/core/cli/mod.rs
+++ b/src/core/cli/mod.rs
@@ -41,12 +41,18 @@ struct ReplArgs {
     /// Optional file to be loaded before entering the REPL
     #[clap(long, value_parser)]
     preload: Option<Utf8PathBuf>,
+
+    #[arg(long)]
+    lurkscript: bool,
 }
 
 #[derive(Parser, Debug)]
 struct ReplCli {
     #[clap(long, value_parser)]
     preload: Option<Utf8PathBuf>,
+
+    #[arg(long)]
+    lurkscript: bool,
 }
 
 #[derive(Args, Debug)]
@@ -85,8 +91,14 @@ fn parse_filename(file: &str) -> Result<Utf8PathBuf> {
 
 impl ReplArgs {
     fn into_cli(self) -> ReplCli {
-        let Self { preload } = self;
-        ReplCli { preload }
+        let Self {
+            preload,
+            lurkscript,
+        } = self;
+        ReplCli {
+            preload,
+            lurkscript,
+        }
     }
 }
 
@@ -117,7 +129,7 @@ impl Cli {
 
 impl ReplCli {
     fn run(&self) -> Result<()> {
-        let mut repl = Repl::new_native();
+        let mut repl = Repl::new_native(self.lurkscript);
         if let Some(lurk_file) = &self.preload {
             repl.load_file(lurk_file, false)?;
         }
@@ -127,7 +139,7 @@ impl ReplCli {
 
 impl LoadCli {
     fn run(&self) -> Result<()> {
-        let mut repl = Repl::new_native();
+        let mut repl = Repl::new_native(false);
         repl.load_file(&self.lurk_file, self.demo)?;
         if self.prove {
             repl.prove_last_reduction()?;

--- a/src/core/cli/paths.rs
+++ b/src/core/cli/paths.rs
@@ -37,6 +37,10 @@ pub(crate) fn microchains_dir() -> Result<Utf8PathBuf> {
 }
 
 #[inline]
-pub(crate) fn repl_history() -> Result<Utf8PathBuf> {
-    Ok(lurk_dir()?.join("repl-history"))
+pub(crate) fn repl_history(lurkscript: bool) -> Result<Utf8PathBuf> {
+    Ok(lurk_dir()?.join(if lurkscript {
+        "lurkscript-repl-history"
+    } else {
+        "repl-history"
+    }))
 }

--- a/src/core/cli/repl.rs
+++ b/src/core/cli/repl.rs
@@ -86,7 +86,7 @@ impl<F: Field> InputValidator<F> {
             .arg("-ce")
             .arg(input)
             .output()
-            .map_err(|_| ())?;
+            .map_err(|_err| ())?;
 
         if output.status.success() {
             // Successfully compiled LurkScript

--- a/src/core/cli/repl.rs
+++ b/src/core/cli/repl.rs
@@ -180,7 +180,7 @@ impl<C1: Chipset<BabyBear>, C2: Chipset<BabyBear>> Repl<BabyBear, C1, C2> {
         let must_prove = if !proof_path.exists() {
             true
         } else {
-            let cached_proof_bytes = std::fs::read(&proof_path)?;
+            let cached_proof_bytes = fs::read(&proof_path)?;
             if let Ok(cached_proof) = bincode::deserialize::<CachedProof>(&cached_proof_bytes) {
                 let machine_proof = cached_proof.into_machine_proof();
                 let challenger_v = &mut challenger_p.clone();
@@ -202,7 +202,7 @@ impl<C1: Chipset<BabyBear>, C2: Chipset<BabyBear>> Repl<BabyBear, C1, C2> {
             let crypto_proof: CryptoProof = machine_proof.into();
             let cached_proof = CachedProof::new(crypto_proof, public_values, &self.zstore);
             let cached_proof_bytes = bincode::serialize(&cached_proof)?;
-            std::fs::write(proof_path, cached_proof_bytes)?;
+            fs::write(proof_path, cached_proof_bytes)?;
         }
         println!("Proof key: \"{proof_key}\"");
         Ok(proof_key)
@@ -622,9 +622,9 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
             } else {
                 print!("{potential_commentaries}{prompt_marker}{actual_syntax}");
             }
-            std::io::stdout().flush()?;
+            io::stdout().flush()?;
             // wait for ENTER to be pressed
-            std::io::stdin().read_line(&mut String::new())?;
+            io::stdin().read_line(&mut String::new())?;
             // ENTER already prints a new line so we can remove it from the start of incoming input
             new_input = new_input.trim_start_matches('\n').into();
         }
@@ -716,7 +716,6 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
 
                     if self.lurkscript {
                         let mut buffer = line + "\n"; // Accumulate multi-line input
-                        let mut first_line = true; // Track first prompt use
 
                         loop {
                             // Try processing accumulated LurkScript input
@@ -731,7 +730,6 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
                                 break; // Proceed to processing
                             } else {
                                 // Assume error = incomplete input, continue reading
-                                first_line = false;
 
                                 // Read another line *without* displaying a new prompt
                                 print!("  "); // Minimal indent for clarity

--- a/src/core/cli/repl.rs
+++ b/src/core/cli/repl.rs
@@ -702,7 +702,7 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
             _marker: Default::default(),
         }));
 
-        let repl_history = &repl_history()?;
+        let repl_history = &repl_history(self.lurkscript)?;
         if repl_history.exists() {
             editor.load_history(repl_history)?;
         }

--- a/src/core/cli/tests/mod.rs
+++ b/src/core/cli/tests/mod.rs
@@ -6,11 +6,11 @@ use crate::core::cli::{
 #[test]
 fn test_meta_commands() {
     set_config_if_unset(Config::default());
-    let mut repl = Repl::new_native();
+    let mut repl = Repl::new_native(false);
     assert!(repl
         .load_file("src/core/cli/tests/first.lurk".into(), false)
         .is_ok());
-    let mut repl = Repl::new_native();
+    let mut repl = Repl::new_native(false);
     assert!(repl
         .load_file("src/core/cli/tests/second.lurk".into(), false)
         .is_ok());
@@ -21,11 +21,11 @@ fn test_meta_commands() {
 #[test]
 fn test_meta_commands_with_proofs() {
     set_config_if_unset(Config::default());
-    let mut repl = Repl::new_native();
+    let mut repl = Repl::new_native(false);
     assert!(repl
         .load_file("src/core/cli/tests/prove.lurk".into(), false)
         .is_ok());
-    let mut repl = Repl::new_native();
+    let mut repl = Repl::new_native(false);
     assert!(repl
         .load_file("src/core/cli/tests/verify.lurk".into(), false)
         .is_ok());
@@ -36,7 +36,7 @@ fn test_meta_commands_with_proofs() {
 #[test]
 fn test_lib() {
     set_config_if_unset(Config::default());
-    let mut repl = Repl::new_native();
+    let mut repl = Repl::new_native(false);
     assert!(repl.load_file("lib/tests.lurk".into(), false).is_ok());
 }
 
@@ -55,7 +55,7 @@ fn test_demo_files() {
         "demo/microbank.lurk",
     ];
     for file in demo_files {
-        let mut repl = Repl::new_native();
+        let mut repl = Repl::new_native(false);
         assert!(repl.load_file(file.into(), false).is_ok());
     }
     std::fs::remove_file("protocol-proof").unwrap();


### PR DESCRIPTION
This PR adds ability to load LurkScript (`.ls`) files and to read LurkScript at the REPL (if run with `--lurkscript` flag).

Note, this work assumes `lurkscript` has been installed and is in the path.

Loading uses file suffix detection to be minimally intrusive.

TODO:
- make `lurkscript` return distinct error on incomplete input vs other cases
- continue to accumulate input when incomplete, but handle and report other errors

examples:
```
(base) ➜  lurk git:(lurkscript) ✗ lurk load 'lib/foo.ls'
commit: 2025-02-07 a7f39b596a456a80677e04addda69d22b95a8e36
Loading lib/foo.ls
[2 iterations] => 2
(base) ➜  lurk git:(lurkscript) ✗ lurk
commit: 2025-02-07 a7f39b596a456a80677e04addda69d22b95a8e36
Lurk REPL welcomes you.
lurk-user> !(load "lib/foo.ls")
Loading /Users/clwk/fil/lurk/lib/foo.ls
[2 iterations] => 2
t
lurk-user> 
Exiting...
(base) ➜  lurk git:(lurkscript) ✗ cat lib/foo.ls
1 + 1;
(base) ➜  lurk git:(lurkscript) ✗ lurk --lurkscript
commit: 2025-02-07 a7f39b596a456a80677e04addda69d22b95a8e36
Lurk REPL welcomes you.
lurk-user> ((x)=>x*x
)(9)
[5 iterations] => 81
lurk-user> 3 * 3;
[2 iterations] => 9
lurk-user>
```