### PR TITLE
fix: Change `create_unknown_packages` default from `false` to `true`

### DIFF
--- a/src/core/cli/repl.rs
+++ b/src/core/cli/repl.rs
@@ -62,7 +62,7 @@ impl<F: Field> InputValidator<F> {
         loop {
             match delimited(
                 parse_space,
-                parse_syntax_eof::<F>(self.state.clone(), false),
+                parse_syntax_eof::<F>(self.state.clone(), true),
                 parse_space,
             )
             .parse(input)
@@ -617,7 +617,7 @@ impl<F: PrimeField32, C1: Chipset<F>, C2: Chipset<F>> Repl<F, C1, C2> {
         input: Span<'a>,
         file_dir: &Utf8Path,
     ) -> Result<Option<(usize, Span<'a>, ZPtr<F>, bool)>> {
-        let Some((rest, syn)) = parse(input, self.state.clone(), false)? else {
+        let Some((rest, syn)) = parse(input, self.state.clone(), true)? else {
             return Ok(None);
         };
         let offset = syn

--- a/src/core/zstore.rs
+++ b/src/core/zstore.rs
@@ -568,7 +568,7 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
         state: StateRcCell,
         lang_symbols: &FxHashSet<Symbol>,
     ) -> ZPtr<F> {
-        let (_, syn) = parse(Span::new(input), state, false)
+        let (_, syn) = parse(Span::new(input), state, true)
             .expect("parse error")
             .expect("no input");
         self.intern_syntax(&syn, lang_symbols)


### PR DESCRIPTION
Changing the default behavior of the parser to create unknown packages for now. The issue is described in this comment: https://github.com/lurk-lab/lurk/issues/422#issuecomment-2657883045

Once we have a better structure around interning symbols from other packages (including possibly unknown packages), this might be changed again in the future.

```
lurk-user> !(def .foo.bar 123) ;; this creates the unknown package `.foo`, by default it's empty
.foo.bar
lurk-user> !(in-package .foo)
.lurk.t
foo> bar
[1 iteration] => 123
foo>
```