### PR TITLE
fix: Reverse the printed/parsed order of env bindings internally

### DIFF
--- a/src/core/parser/syntax.rs
+++ b/src/core/parser/syntax.rs
@@ -472,10 +472,12 @@ fn parse_env<F: Field>(
     move |from: Span<'_>| {
         let (i, _) = tag("{")(from)?;
         let (i, _) = parse_space(i)?;
-        let (i, pairs) = separated_list0(
+        let (i, mut pairs) = separated_list0(
             tag(","),
             parse_env_pair(state.clone(), create_unknown_packages),
         )(i)?;
+        // We want the last entry to be the most significant one, so reverse the internal representation
+        pairs.reverse();
         let (upto, _) = tag("}")(i)?;
         let pos = Pos::from_upto(from, upto);
         Ok((upto, Syntax::Env(pos, pairs)))

--- a/src/core/tests/eval_direct.rs
+++ b/src/core/tests/eval_direct.rs
@@ -367,7 +367,7 @@ test!(test_env_builtin3, "(env (list 'a 1 2))", |z| {
     let val = z.intern_list([one, two]);
     z.intern_env(a, val, empty_env)
 });
-test!(test_env_literal, "{ a: 1, b: 2 }", |z| {
+test!(test_env_literal, "{ b: 2, a: 1 }", |z| {
     let empty_env = z.intern_empty_env();
     let b = z.intern_symbol_no_lang(&user_sym("b"));
     let two = z.intern_u64(2);

--- a/src/core/tests/eval_direct.rs
+++ b/src/core/tests/eval_direct.rs
@@ -377,7 +377,7 @@ test!(test_env_literal, "{ b: 2, a: 1 }", |z| {
     z.intern_env(a, one, b_2)
 });
 test!(test_env_literal_empty, "{  }", |z| { z.intern_empty_env() });
-test!(test_env_literal_add, "{ a: (+ 1 0), b: 2 }", |z| {
+test!(test_env_literal_add, "{ b: 2, a: (+ 1 0) }", |z| {
     let empty_env = z.intern_empty_env();
     let b = z.intern_symbol_no_lang(&user_sym("b"));
     let two = z.intern_u64(2);

--- a/src/core/tests/eval_direct.rs
+++ b/src/core/tests/eval_direct.rs
@@ -400,6 +400,11 @@ test!(test_env_literal_err, "{ a: (1 1), b: 2 }", |_| {
     ZPtr::err(EvalErr::ApplyNonFunc)
 });
 test!(
+    test_env_literal_ordering,
+    "(eval 'a { a: 1, b: 2, a: 3 })",
+    |z| z.intern_u64(3)
+);
+test!(
     test_bind_builtin,
     "(bind 'a (- 2 1) (current-env))",
     trivial_a_1_env

--- a/src/core/zstore.rs
+++ b/src/core/zstore.rs
@@ -878,6 +878,7 @@ impl<F: Field, C: Chipset<F>> ZStore<F, C> {
                 let pairs_str = self
                     .fetch_env(zptr)
                     .iter()
+                    .rev()
                     .map(|(sym, val)| {
                         format!(
                             "{}: {}",


### PR DESCRIPTION
Fixes #417

Before:
```
lurk-user> (eval 'a { a: 1, b: 2, a: 3 })
[7 iterations] => 1
lurk-user> !(def a 1)
a
lurk-user> !(def a 2)
a
lurk-user> (current-env)
[1 iteration] => { a: 2, a: 1 }
```

After:
```
lurk-user> (eval 'a { a: 1, b: 2, a: 3 })
[7 iterations] => 3
lurk-user> { a: 1, b: 2, a: 3 }
[4 iterations] => { a: 1, b: 2, a: 3 }
lurk-user> !(def a 1)
a
lurk-user> !(def a 2)
a
lurk-user> (current-env)
[1 iteration] => { a: 1, a: 2 }
```