### PR TITLE
lib tests with standalone lurkscript

### DIFF
--- a/lib/struct.ls
+++ b/lib/struct.ls
@@ -6,7 +6,7 @@ def(alistStruct, function (fields) {
   return function (op) {
     if (op === 'new'.key) {
       return function (vals) {
-        const alist = emit(zip(fields, vals));
+        const alist = zip(fields, vals);
         field => cdr(assoc(field, alist))
       }
     }

--- a/lib/struct.lurk
+++ b/lib/struct.lurk
@@ -8,7 +8,7 @@
                        ;; However this allows an interface that abstracts the implementation.
                        (if (eq op :new)
                            (lambda (vals)
-                             (let ((alist (emit (zip fields vals))))
+                             (let ((alist (zip fields vals)))
                                (lambda (field)
                                  (cdr (assoc field alist)))))))))
 

--- a/lib/util-test.ls
+++ b/lib/util-test.ls
@@ -3,7 +3,7 @@ load.meta('util.ls')
 assertError(todo(restOfOwl.key))
 
 // error
-assertError(error(nasty.key, 123))
+assertError(error(nasty.key))
 
 // assert
 // FIXME: This requires #422 to be fixed.

--- a/lib/util-test.lurk
+++ b/lib/util-test.lurk
@@ -4,7 +4,7 @@
 !(assert-error (todo :rest-of-owl))
 
 ;; error
-!(assert-error (error :nasty 123))
+!(assert-error (error :nasty))
 
 ;; assert_
 !(assert-eq 9 (assert_ 9))

--- a/lib/util.ls
+++ b/lib/util.ls
@@ -20,8 +20,8 @@ def(todo, x => { emit(list(todo.key, x));
                  BREAK()
                })
 
-def(error, data => {
-  emit(list(error.key, data))
+def(err, data => {
+  emit(list(error.key, data));
   // this will error
   BREAK()
 })

--- a/src/core/cli/tests/mod.rs
+++ b/src/core/cli/tests/mod.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use crate::core::cli::{
     config::{set_config_if_unset, Config},
     repl::Repl,
@@ -46,6 +48,18 @@ fn test_lib_ls() {
     set_config_if_unset(Config::default());
     let mut repl = Repl::new_native(false);
     assert!(repl.load_file("lib/tests.ls".into(), false).is_ok());
+}
+
+#[ignore]
+#[test]
+fn test_lib_ls_lurkscript() {
+    set_config_if_unset(Config::default());
+    let output = Command::new("lurkscript")
+        .arg("lib/tests.ls")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
 }
 
 #[ignore]


### PR DESCRIPTION
This PR add a test to run `lib/tests.ls` with `lurkscript`. It also contains a few small clean-up items discovered while ensuring `lurkscript` the new test will pass.